### PR TITLE
Add missing swagger-ui-react dependency

### DIFF
--- a/src/components/swagger.ts
+++ b/src/components/swagger.ts
@@ -1,4 +1,4 @@
-export const swaggerDeps = ["swagger-ui"];
+export const swaggerDeps = ["swagger-ui", "swagger-ui-react"];
 
 export function SwaggerUI(outputFile: string) {
   return `


### PR DESCRIPTION
Fixes missing swagger-ui-react dependency. 

Ref: (https://github.com/tazo90/next-openapi-gen/issues/1)