### PR TITLE
fix: ensure LF line endings for compatibility (#4)

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "esnext",
     "outDir": "./dist",
     "rootDir": "./src",
+    "newLine": "lf",
     "esModuleInterop": true,
     "moduleResolution": "node",
     "strict": false,


### PR DESCRIPTION
This ensures that when `tsc` builds it will output `dist/index.js` with LF endings for cross-platform compatibility.