### PR TITLE
fix: Support for TSUnionNode between type object references

### DIFF
--- a/src/lib/schema-processor.ts
+++ b/src/lib/schema-processor.ts
@@ -240,6 +240,10 @@ export class SchemaProcessor {
         };
       }
 
+      if (t.isTSUnionType(typeNode)) {
+        return this.resolveTSNodeType(typeNode);
+      }
+
       return {};
     } finally {
       // Remove type from processed set after we finish


### PR DESCRIPTION
I have an example like:
```
export type Foo = {
  key1: val1
  key2: val2
}
export type Bar = {
  key1: val1
  key2: val2
} 
export type RequestBody = Foo | Bar;
```

But this type was not being supported by default. I did some debug logging in my project's node modules to see that `resolveType` helper was being called for the RequestBody type from this example, but there was no handling for it as a union node in this helper's implementation, as the logic for unions seems to live only in its parent function `resolveToTSNode`. So I just called back to `resolveToTSNode` from this point to handle the union which fixed this example in my case.


Let me know if I'm missing anything, thanks!