### PR TITLE
fix: resolve invalid flag usage by branching for yarn and pnpm

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -56,6 +56,22 @@ function getDocsPage(ui: string, outputFile: string) {
   return DocsComponent(outputFile);
 }
 
+function getDocsPageInstallFlags(ui: string, packageManager: string) {
+  let installFlags = "";
+  if (ui === "swagger") {
+    // @temp: swagger-ui-react does not support React 19 now.
+    if (packageManager === "pnpm") {
+      installFlags = "--no-strict-peer-dependencies";
+    } else if (packageManager === "yarn") {
+      installFlags = ""; // flag for legacy peer deps is not needed for yarn
+    } else {
+      installFlags = "--legacy-peer-deps";
+    }
+  }
+
+  return installFlags;
+}
+
 function getDocsPageDependencies(ui: string) {
   let deps = [];
 
@@ -99,9 +115,10 @@ async function installDependencies(ui: string) {
   }`;
 
   const deps = getDocsPageDependencies(ui);
+  const flags = getDocsPageInstallFlags(ui, packageManager);
 
   spinner.succeed(`Installing ${deps} dependencies...`);
-  const resp = await execPromise(`${installCmd} ${deps}`);
+  const resp = await execPromise(`${installCmd} ${deps} ${flags}`);
   spinner.succeed(`Successfully installed ${deps}.`);
 }
 

--- a/src/components/swagger.ts
+++ b/src/components/swagger.ts
@@ -1,8 +1,4 @@
-export const swaggerDeps = [
-  "swagger-ui",
-  "swagger-ui-react",
-  "--legacy-peer-deps", // @temp: swagger-ui-react does not support React 19 now.
-];
+export const swaggerDeps = ["swagger-ui", "swagger-ui-react"];
 
 export function SwaggerUI(outputFile: string) {
   return `


### PR DESCRIPTION
Previously, using unsupported flags like `--legacy-peer-deps` caused errors with yarn and pnpm. Added proper branching logic per package manager to avoid these installation issues.

Added `getDocsPageInstallFlags` method to determine proper installation flags  
based on the selected package manager when using the Swagger UI.  

```typescript
// src/commands/init.ts

function getDocsPageInstallFlags(ui: string, packageManager: string) {
  let installFlags = "";
  if (ui === "swagger") {
    // @temp: swagger-ui-react does not support React 19 now.
    if (packageManager === "pnpm") {
      installFlags = "--no-strict-peer-dependencies";
    } else if (packageManager === "yarn") {
      installFlags = ""; // flag for legacy peer deps is not needed for yarn
    } else {
      installFlags = "--legacy-peer-deps";
    }
  }

  return installFlags;
}

// ...

async function installDependencies(ui: string) {
  const packageManager = await getPackageManager();
  const installCmd = `${packageManager} ${
    packageManager === "npm" ? "install" : "add"
  }`;

  const deps = getDocsPageDependencies(ui);
  const flags = getDocsPageInstallFlags(ui, packageManager);

  spinner.succeed(`Installing ${deps} dependencies...`);
  const resp = await execPromise(`${installCmd} ${deps} ${flags}`);
  spinner.succeed(`Successfully installed ${deps}.`);
}
```

- For `pnpm`, applies `--no-strict-peer-dependencies`  
- For `yarn`, no additional flag is required  
- For `npm`, applies `--legacy-peer-deps`  

This prevents errors caused by unsupported flags in different package managers.
Verified installation works correctly with yarn, pnpm, and npm.

Refs #32