### PR TITLE
feat: add --ui none and --output options

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Automatically generate OpenAPI 3.0 documentation from Next.js projects, with sup
 - Stoplight Elements
 - RapiDoc
 
+> [!TIP]
+> You can use the `--ui none` option during initialization to skip UI setup if you only care about generating the OpenAPI documentation.
+
 ## Installation
 
 ```bash
@@ -35,6 +38,9 @@ npx next-openapi-gen init --ui scalar --docs-url api-docs --schema zod
 # Generate OpenAPI documentation
 npx next-openapi-gen generate
 ```
+
+> [!TIP]
+> Use the `--output` option in the `init` command to specify a custom output file for the template. Then you can use the `--template` option in the `generate` command to point to that file.
 
 ## Configuration
 

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -5,10 +5,14 @@ import ora from "ora";
 
 import { OpenApiGenerator } from "../lib/openapi-generator.js";
 
-export async function generate() {
+export async function generate(options) {
+  const { template } = options;
+
   const spinner = ora("Generating OpenAPI specification...\n").start();
 
-  const generator = new OpenApiGenerator();
+  const generator = new OpenApiGenerator({
+    templatePath: template,
+  });
   const config = generator.getConfig();
 
   // Create api dir if not exists

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -91,6 +91,10 @@ function getDocsPageDependencies(ui: string) {
 }
 
 async function createDocsPage(ui: string, outputFile: string) {
+  if (ui === "none") {
+    return;
+  }
+
   const paths = ["app", "api-docs"];
   const srcPath = path.join(process.cwd(), "src");
 
@@ -109,6 +113,10 @@ async function createDocsPage(ui: string, outputFile: string) {
 }
 
 async function installDependencies(ui: string) {
+  if (ui === "none") {
+    return;
+  }
+
   const packageManager = await getPackageManager();
   const installCmd = `${packageManager} ${
     packageManager === "npm" ? "install" : "add"
@@ -128,19 +136,27 @@ function extendOpenApiTemplate(spec, options) {
   spec.schemaType = options.schema ?? spec.schemaType;
 }
 
+function getOutputPath(output?: string) {
+  if (output) {
+    return path.isAbsolute(output) ? output : path.join(process.cwd(), output);
+  }
+
+  return path.join(process.cwd(), "next.openapi.json");
+}
+
 export async function init(options) {
-  const { ui } = options;
+  const { ui, output } = options;
 
   spinner.start();
 
   try {
-    const outputPath = path.join(process.cwd(), "next.openapi.json");
+    const outputPath = getOutputPath(output);
     const template = { ...openapiTemplate };
 
     extendOpenApiTemplate(template, options);
 
     await fse.writeJson(outputPath, template, { spaces: 2 });
-    spinner.succeed(`Created OpenAPI template in next.openapi.json`);
+    spinner.succeed(`Created OpenAPI template in ${outputPath}`);
 
     createDocsPage(ui, template.outputFile);
     installDependencies(ui);

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,8 +17,8 @@ program
 program
   .command("init")
   .addOption(
-    new Option("-i, --ui <type>", "Specify the UI type, e.g., scalar")
-      .choices(["scalar", "swagger", "redoc", "stoplight", "rapidoc"])
+    new Option("-i, --ui <type>", "Specify the UI type, e.g., scalar. Use \"none\" for no UI")
+      .choices(["scalar", "swagger", "redoc", "stoplight", "rapidoc", "none"])
       .default("swagger")
   )
   .option("-u, --docs-url <url>", "Specify the docs URL", "api-docs")
@@ -27,12 +27,14 @@ program
       .choices(["zod", "typescript"])
       .default("zod")
   )
+  .option("-o, --output <file>", "Specify the output path for the OpenAPI template.", "next.openapi.json")
   .description("Initialize a openapi specification")
   .action(init);
 
 program
   .command("generate")
   .description("Generate a specification based on api routes")
+  .option("-t, --template <file>", "Specify the OpenAPI template file", "next.openapi.json")
   .action(generate);
 
 program.parse(process.argv);

--- a/src/lib/openapi-generator.ts
+++ b/src/lib/openapi-generator.ts
@@ -11,13 +11,17 @@ import {
 } from "../types.js";
 import { logger } from "./logger.js";
 
+export type OpenApiGeneratorOptions = {
+  templatePath?: string;
+}
+
 export class OpenApiGenerator {
   private config: OpenApiConfig;
   private template: OpenApiTemplate;
   private routeProcessor: RouteProcessor;
 
-  constructor() {
-    const templatePath = path.resolve("./next.openapi.json");
+  constructor(opts: OpenApiGeneratorOptions = {}) {
+    const templatePath = opts.templatePath || path.resolve("./next.openapi.json");
 
     this.template = JSON.parse(fs.readFileSync(templatePath, "utf-8"));
     this.config = this.getConfig();


### PR DESCRIPTION
## Description

This PR introduces the following changes:

1. Adds a `none` option to the `init` command's `--ui` argument, which allows users to use the program just to create the OpenAPI specification file. When the `none` option is used, the program will not install any dependencies or create any files other than the template. (closes #10)
1. Adds an `--output` argument to the `init` command, which lets users specify the output path of the template. This path can be absolute or relative. (closes #45)
1. Adds a `--template` argument to the `generate` command, which users can use to point to a different template file.

## Type of Change

- [x] ✨ **feat:** New feature
- [ ] � **fix:** Bug fix
- [ ] 📝 **docs:** Documentation update
- [ ] ♻️ **refactor:** Code refactoring
- [ ] ⚡ **perf:** Performance improvement
- [ ] 💥 **Breaking change** (add `!` after type, e.g., `feat!:`)

## Checklist

- [x] Code follows project style
- [x] Tested locally
- [x] Documentation updated (if needed)