### PR TITLE
fix: remove `schemaFiles` and `outputDir` from generated file

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -219,6 +219,8 @@ export function cleanSpec(spec: any) {
     "responseSets",
     "errorConfig",
     "debug",
+    "schemaFiles",
+    "outputDir",
   ];
   const newSpec = { ...spec };
 


### PR DESCRIPTION
## Description

These two properties were not getting cleaned up, which resulted in some strict OpenAPI spec validators to fail.

## Type of Change

- [ ] ✨ **feat:** New feature
- [x] � **fix:** Bug fix
- [ ] 📝 **docs:** Documentation update
- [ ] ♻️ **refactor:** Code refactoring
- [ ] ⚡ **perf:** Performance improvement
- [ ] 💥 **Breaking change** (add `!` after type, e.g., `feat!:`)

## Checklist

- [x] Code follows project style
- [x] Tested locally
- [ ] Documentation updated (if needed)