### PR TITLE
fix: support array notation in @response and @body annotations (Type[])

### DIFF
--- a/examples/next15-app-drizzle-zod/public/openapi.json
+++ b/examples/next15-app-drizzle-zod/public/openapi.json
@@ -72,7 +72,10 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PostResponseSchema[]"
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PostResponseSchema"
+                  }
                 }
               }
             }
@@ -303,7 +306,55 @@
           }
         }
       },
-      "PostResponseSchema[]": {},
+      "PostResponseSchema": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "Post title"
+          },
+          "slug": {
+            "type": "string",
+            "description": "URL-friendly slug"
+          },
+          "excerpt": {
+            "type": "string",
+            "description": "Post excerpt"
+          },
+          "content": {
+            "type": "string",
+            "description": "Full post content"
+          },
+          "published": {
+            "type": "boolean",
+            "description": "Publication status"
+          },
+          "viewCount": {
+            "type": "integer",
+            "description": "Number of views"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Creation timestamp"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Last update timestamp"
+          }
+        },
+        "required": [
+          "title",
+          "slug",
+          "excerpt",
+          "content",
+          "published",
+          "viewCount",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
       "CreatePostSchema": {
         "type": "object",
         "properties": {
@@ -359,55 +410,6 @@
         },
         "required": [
           "id"
-        ]
-      },
-      "PostResponseSchema": {
-        "type": "object",
-        "properties": {
-          "title": {
-            "type": "string",
-            "description": "Post title"
-          },
-          "slug": {
-            "type": "string",
-            "description": "URL-friendly slug"
-          },
-          "excerpt": {
-            "type": "string",
-            "description": "Post excerpt"
-          },
-          "content": {
-            "type": "string",
-            "description": "Full post content"
-          },
-          "published": {
-            "type": "boolean",
-            "description": "Publication status"
-          },
-          "viewCount": {
-            "type": "integer",
-            "description": "Number of views"
-          },
-          "createdAt": {
-            "type": "string",
-            "format": "date-time",
-            "description": "Creation timestamp"
-          },
-          "updatedAt": {
-            "type": "string",
-            "format": "date-time",
-            "description": "Last update timestamp"
-          }
-        },
-        "required": [
-          "title",
-          "slug",
-          "excerpt",
-          "content",
-          "published",
-          "viewCount",
-          "createdAt",
-          "updatedAt"
         ]
       },
       "UpdatePostSchema": {

--- a/examples/next15-app-zod/public/openapi.json
+++ b/examples/next15-app-zod/public/openapi.json
@@ -2326,7 +2326,7 @@
     "/users-paginated": {
       "get": {
         "operationId": "get-users-paginated",
-        "summary": "Get paginated users",
+        "summary": "Get paginated users\r",
         "description": "Retrieve users with cursor-based pagination using factory-generated schema",
         "tags": [
           "Users-paginated"

--- a/src/lib/schema-processor.ts
+++ b/src/lib/schema-processor.ts
@@ -1059,12 +1059,26 @@ export class SchemaProcessor {
     body: OpenAPIDefinition;
     responses: OpenAPIDefinition;
   } {
+    // Helper function to strip array notation from type names
+    const stripArrayNotation = (typeName: string | undefined): string | undefined => {
+      if (!typeName) return typeName;
+      let baseType = typeName;
+      while (baseType.endsWith('[]')) {
+        baseType = baseType.slice(0, -2);
+      }
+      return baseType;
+    };
+
+    // Strip array notation for schema lookups
+    const baseBodyType = stripArrayNotation(bodyType);
+    const baseResponseType = stripArrayNotation(responseType);
+
     let params = paramsType ? this.openapiDefinitions[paramsType] : {};
     let pathParams = pathParamsType
       ? this.openapiDefinitions[pathParamsType]
       : {};
-    let body = bodyType ? this.openapiDefinitions[bodyType] : {};
-    let responses = responseType ? this.openapiDefinitions[responseType] : {};
+    let body = baseBodyType ? this.openapiDefinitions[baseBodyType] : {};
+    let responses = baseResponseType ? this.openapiDefinitions[baseResponseType] : {};
 
     if (paramsType && !params) {
       this.findSchemaDefinition(paramsType, "params");
@@ -1076,22 +1090,22 @@ export class SchemaProcessor {
       pathParams = this.openapiDefinitions[pathParamsType] || {};
     }
 
-    if (bodyType && !body) {
-      this.findSchemaDefinition(bodyType, "body");
-      body = this.openapiDefinitions[bodyType] || {};
+    if (baseBodyType && !body) {
+      this.findSchemaDefinition(baseBodyType, "body");
+      body = this.openapiDefinitions[baseBodyType] || {};
     }
 
-    if (responseType && !responses) {
-      this.findSchemaDefinition(responseType, "response");
-      responses = this.openapiDefinitions[responseType] || {};
+    if (baseResponseType && !responses) {
+      this.findSchemaDefinition(baseResponseType, "response");
+      responses = this.openapiDefinitions[baseResponseType] || {};
     }
 
     if (this.schemaTypes.includes("zod")) {
       const schemasToProcess = [
         paramsType,
         pathParamsType,
-        bodyType,
-        responseType,
+        baseBodyType,
+        baseResponseType,
       ].filter(Boolean);
       schemasToProcess.forEach((schemaName) => {
         if (!this.openapiDefinitions[schemaName]) {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -193,10 +193,10 @@ export function extractTypeFromComment(
   commentValue: string,
   tag: string
 ): string {
-  // Updated regex to support generic types with angle brackets
+  // Updated regex to support generic types with angle brackets and array brackets
   return (
     commentValue
-      .match(new RegExp(`${tag}\\s*\\s*([\\w<>,\\s]+)`))?.[1]
+      .match(new RegExp(`${tag}\\s*\\s*([\\w<>,\\s\\[\\]]+)`))?.[1]
       ?.trim() || ""
   );
 }

--- a/tests/response-array.test.ts
+++ b/tests/response-array.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { extractTypeFromComment } from "../src/lib/utils";
+
+describe("Array Response Annotation Parsing", () => {
+  describe("extractTypeFromComment with array notation", () => {
+    it("should extract single-dimensional array types", () => {
+      const comment = "@response PostResponseSchema[]";
+      const result = extractTypeFromComment(comment, "@response");
+      expect(result).toBe("PostResponseSchema[]");
+    });
+
+    it("should extract multi-dimensional array types", () => {
+      const comment = "@response PostResponseSchema[][]";
+      const result = extractTypeFromComment(comment, "@response");
+      expect(result).toBe("PostResponseSchema[][]");
+    });
+
+    it("should extract generic types with array suffix", () => {
+      const comment = "@response Response<Data>[]";
+      const result = extractTypeFromComment(comment, "@response");
+      expect(result).toBe("Response<Data>[]");
+    });
+
+    it("should extract nested generic types with array suffix", () => {
+      const comment = "@response ApiResponse<User<Details>>[]";
+      const result = extractTypeFromComment(comment, "@response");
+      expect(result).toBe("ApiResponse<User<Details>>[]");
+    });
+
+    it("should handle non-array types normally", () => {
+      const comment = "@response UserResponse";
+      const result = extractTypeFromComment(comment, "@response");
+      expect(result).toBe("UserResponse");
+    });
+
+    it("should handle generic types without arrays", () => {
+      const comment = "@response Response<Data>";
+      const result = extractTypeFromComment(comment, "@response");
+      expect(result).toBe("Response<Data>");
+    });
+
+    it("should handle array types with status codes", () => {
+      // Note: Status codes are parsed separately by the responseMatch regex in extractJSDocComments
+      // extractTypeFromComment only extracts the type part
+      const comment = "@response 200:PostResponseSchema[]";
+      const responseMatch = comment.match(
+        /@response\s+(?:(\d+):)?([^@\n\r]+)(?:\s+(.*))?/
+      );
+      expect(responseMatch).toBeTruthy();
+      if (responseMatch) {
+        const [, code, type] = responseMatch;
+        expect(code).toBe("200");
+        expect(type?.trim()).toBe("PostResponseSchema[]");
+      }
+    });
+
+    it("should extract array types from @body annotation", () => {
+      const comment = "@body CreatePostSchema[]";
+      const result = extractTypeFromComment(comment, "@body");
+      expect(result).toBe("CreatePostSchema[]");
+    });
+  });
+
+  describe("Array depth parsing logic", () => {
+    it("should correctly count array depth for single array", () => {
+      let baseType = "Type[]";
+      let arrayDepth = 0;
+
+      while (baseType.endsWith("[]")) {
+        arrayDepth++;
+        baseType = baseType.slice(0, -2);
+      }
+
+      expect(arrayDepth).toBe(1);
+      expect(baseType).toBe("Type");
+    });
+
+    it("should correctly count array depth for double array", () => {
+      let baseType = "Type[][]";
+      let arrayDepth = 0;
+
+      while (baseType.endsWith("[]")) {
+        arrayDepth++;
+        baseType = baseType.slice(0, -2);
+      }
+
+      expect(arrayDepth).toBe(2);
+      expect(baseType).toBe("Type");
+    });
+
+    it("should correctly count array depth for triple array", () => {
+      let baseType = "Type[][][]";
+      let arrayDepth = 0;
+
+      while (baseType.endsWith("[]")) {
+        arrayDepth++;
+        baseType = baseType.slice(0, -2);
+      }
+
+      expect(arrayDepth).toBe(3);
+      expect(baseType).toBe("Type");
+    });
+
+    it("should handle generic types with arrays", () => {
+      let baseType = "Generic<T>[]";
+      let arrayDepth = 0;
+
+      while (baseType.endsWith("[]")) {
+        arrayDepth++;
+        baseType = baseType.slice(0, -2);
+      }
+
+      expect(arrayDepth).toBe(1);
+      expect(baseType).toBe("Generic<T>");
+    });
+  });
+
+  describe("Schema structure generation", () => {
+    it("should generate correct schema for single array", () => {
+      const baseType = "PostResponseSchema";
+      const arrayDepth = 1;
+
+      let schema: any = { $ref: `#/components/schemas/${baseType}` };
+      for (let i = 0; i < arrayDepth; i++) {
+        schema = {
+          type: "array",
+          items: schema,
+        };
+      }
+
+      expect(schema).toEqual({
+        type: "array",
+        items: {
+          $ref: "#/components/schemas/PostResponseSchema",
+        },
+      });
+    });
+
+    it("should generate correct schema for double array", () => {
+      const baseType = "PostResponseSchema";
+      const arrayDepth = 2;
+
+      let schema: any = { $ref: `#/components/schemas/${baseType}` };
+      for (let i = 0; i < arrayDepth; i++) {
+        schema = {
+          type: "array",
+          items: schema,
+        };
+      }
+
+      expect(schema).toEqual({
+        type: "array",
+        items: {
+          type: "array",
+          items: {
+            $ref: "#/components/schemas/PostResponseSchema",
+          },
+        },
+      });
+    });
+
+    it("should generate correct schema for non-array type", () => {
+      const baseType = "PostResponseSchema";
+      const arrayDepth = 0;
+
+      let schema: any;
+      if (arrayDepth === 0) {
+        schema = { $ref: `#/components/schemas/${baseType}` };
+      } else {
+        schema = { $ref: `#/components/schemas/${baseType}` };
+        for (let i = 0; i < arrayDepth; i++) {
+          schema = {
+            type: "array",
+            items: schema,
+          };
+        }
+      }
+
+      expect(schema).toEqual({
+        $ref: "#/components/schemas/PostResponseSchema",
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Description

Properly parse array notation in `@response` and `@body` annotations.

## Type of Change

- [ ] ✨ **feat:** New feature
- [x] � **fix:** Bug fix
- [ ] 📝 **docs:** Documentation update
- [ ] ♻️ **refactor:** Code refactoring
- [ ] ⚡ **perf:** Performance improvement
- [ ] 💥 **Breaking change** (add `!` after type, e.g., `feat!:`)

## Checklist

- [x] Code follows project style
- [x] Tested locally
- [ ] Documentation updated (if needed)

Closes: #52 