### PR TITLE
fix: resolve nested Zod schema references in envelope objects

### DIFF
--- a/examples/next15-app-zod/public/openapi.json
+++ b/examples/next15-app-zod/public/openapi.json
@@ -20,6 +20,169 @@
       }
     },
     "schemas": {
+      "OrderIdParams": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Order ID"
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
+      "OrderSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Order ID"
+          },
+          "userId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "User ID"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CartItemSchema"
+            },
+            "description": "Purchased products"
+          },
+          "shippingAddress": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AddressSchema"
+              }
+            ],
+            "description": "Shipping address"
+          },
+          "billingAddress": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AddressSchema"
+              }
+            ],
+            "description": "Billing address (can be the same as shipping address)"
+          },
+          "paymentMethod": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PaymentMethodSchema"
+              }
+            ],
+            "description": "Payment method"
+          },
+          "status": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OrderStatusSchema"
+              }
+            ],
+            "description": "Order status"
+          },
+          "subtotal": {
+            "type": "number",
+            "minimum": 0,
+            "description": "Subtotal (without discount and shipping)"
+          },
+          "discountAmount": {
+            "type": "number",
+            "minimum": 0,
+            "default": 0,
+            "description": "Discount amount"
+          },
+          "shippingCost": {
+            "type": "number",
+            "minimum": 0,
+            "description": "Shipping cost"
+          },
+          "tax": {
+            "type": "number",
+            "minimum": 0,
+            "description": "Tax"
+          },
+          "total": {
+            "type": "number",
+            "minimum": 0,
+            "description": "Total amount"
+          },
+          "notes": {
+            "type": "string",
+            "nullable": true,
+            "description": "Additional notes"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Order creation date"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Last update date"
+          },
+          "paymentDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "Payment date"
+          },
+          "shippingDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "Shipping date"
+          },
+          "deliveryDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "Delivery date"
+          }
+        },
+        "required": [
+          "id",
+          "userId",
+          "items",
+          "shippingAddress",
+          "billingAddress",
+          "paymentMethod",
+          "status",
+          "subtotal",
+          "discountAmount",
+          "shippingCost",
+          "tax",
+          "total",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "UpdateOrderStatusBody": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OrderStatusSchema"
+              }
+            ],
+            "description": "New order status"
+          },
+          "notes": {
+            "type": "string",
+            "nullable": true,
+            "description": "Additional notes about the status change"
+          }
+        },
+        "required": [
+          "status"
+        ]
+      },
       "OrdersQueryParams": {
         "type": "object",
         "properties": {
@@ -174,169 +337,6 @@
         },
         "required": [
           "cartId"
-        ]
-      },
-      "OrderSchema": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid",
-            "description": "Order ID"
-          },
-          "userId": {
-            "type": "string",
-            "format": "uuid",
-            "description": "User ID"
-          },
-          "items": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/CartItemSchema"
-            },
-            "description": "Purchased products"
-          },
-          "shippingAddress": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/AddressSchema"
-              }
-            ],
-            "description": "Shipping address"
-          },
-          "billingAddress": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/AddressSchema"
-              }
-            ],
-            "description": "Billing address (can be the same as shipping address)"
-          },
-          "paymentMethod": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/PaymentMethodSchema"
-              }
-            ],
-            "description": "Payment method"
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OrderStatusSchema"
-              }
-            ],
-            "description": "Order status"
-          },
-          "subtotal": {
-            "type": "number",
-            "minimum": 0,
-            "description": "Subtotal (without discount and shipping)"
-          },
-          "discountAmount": {
-            "type": "number",
-            "minimum": 0,
-            "default": 0,
-            "description": "Discount amount"
-          },
-          "shippingCost": {
-            "type": "number",
-            "minimum": 0,
-            "description": "Shipping cost"
-          },
-          "tax": {
-            "type": "number",
-            "minimum": 0,
-            "description": "Tax"
-          },
-          "total": {
-            "type": "number",
-            "minimum": 0,
-            "description": "Total amount"
-          },
-          "notes": {
-            "type": "string",
-            "nullable": true,
-            "description": "Additional notes"
-          },
-          "createdAt": {
-            "type": "string",
-            "format": "date-time",
-            "description": "Order creation date"
-          },
-          "updatedAt": {
-            "type": "string",
-            "format": "date-time",
-            "description": "Last update date"
-          },
-          "paymentDate": {
-            "type": "string",
-            "format": "date-time",
-            "nullable": true,
-            "description": "Payment date"
-          },
-          "shippingDate": {
-            "type": "string",
-            "format": "date-time",
-            "nullable": true,
-            "description": "Shipping date"
-          },
-          "deliveryDate": {
-            "type": "string",
-            "format": "date-time",
-            "nullable": true,
-            "description": "Delivery date"
-          }
-        },
-        "required": [
-          "id",
-          "userId",
-          "items",
-          "shippingAddress",
-          "billingAddress",
-          "paymentMethod",
-          "status",
-          "subtotal",
-          "discountAmount",
-          "shippingCost",
-          "tax",
-          "total",
-          "createdAt",
-          "updatedAt"
-        ]
-      },
-      "OrderIdParams": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid",
-            "description": "Order ID"
-          }
-        },
-        "required": [
-          "id"
-        ]
-      },
-      "UpdateOrderStatusBody": {
-        "type": "object",
-        "properties": {
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OrderStatusSchema"
-              }
-            ],
-            "description": "New order status"
-          },
-          "notes": {
-            "type": "string",
-            "nullable": true,
-            "description": "Additional notes about the status change"
-          }
-        },
-        "required": [
-          "status"
         ]
       },
       "ProductQueryParams": {
@@ -593,28 +593,27 @@
           "uploadedAt"
         ]
       },
-      "UserListParamsSchema": {
+      "UserFieldsQuery": {
         "type": "object",
         "properties": {
-          "pagination": {
-            "type": "object"
-          },
-          "filter": {
-            "type": "object",
-            "properties": {
-              "name": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "name"
-            ],
-            "nullable": true
+          "fields": {
+            "type": "string",
+            "nullable": true,
+            "description": "Comma-separated list of fields to include"
+          }
+        }
+      },
+      "UserIdParams": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "User ID"
           }
         },
         "required": [
-          "pagination",
-          "pagination"
+          "id"
         ]
       },
       "UserDetailedSchema": {
@@ -651,29 +650,6 @@
           "email",
           "name",
           "role"
-        ]
-      },
-      "UserFieldsQuery": {
-        "type": "object",
-        "properties": {
-          "fields": {
-            "type": "string",
-            "nullable": true,
-            "description": "Comma-separated list of fields to include"
-          }
-        }
-      },
-      "UserIdParams": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid",
-            "description": "User ID"
-          }
-        },
-        "required": [
-          "id"
         ]
       },
       "UpdateUserBody": {
@@ -731,6 +707,29 @@
             "description": "User preferences"
           }
         }
+      },
+      "UserListParamsSchema": {
+        "type": "object",
+        "properties": {
+          "pagination": {
+            "$ref": "#/components/schemas/PaginationSchema"
+          },
+          "filter": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "nullable": true
+          }
+        },
+        "required": [
+          "pagination"
+        ]
       },
       "PaginationMeta": {
         "type": "object",
@@ -1668,7 +1667,7 @@
     "/orders": {
       "get": {
         "operationId": "get-orders",
-        "summary": "Get orders list\r",
+        "summary": "Get orders list",
         "description": "Retrieves a paginated list of orders with filtering and sorting options",
         "tags": [
           "Orders"
@@ -1766,7 +1765,7 @@
       },
       "post": {
         "operationId": "post-orders",
-        "summary": "Create order\r",
+        "summary": "Create order",
         "description": "Creates a new order from cart",
         "tags": [
           "Orders"
@@ -1853,7 +1852,7 @@
       },
       "patch": {
         "operationId": "patch-orders-{id}",
-        "summary": "Update order status\r",
+        "summary": "Update order status",
         "description": "Updates the status of an order",
         "tags": [
           "Orders"
@@ -1906,7 +1905,7 @@
       },
       "delete": {
         "operationId": "delete-orders-{id}",
-        "summary": "Cancel order\r",
+        "summary": "Cancel order",
         "description": "Cancels an order if it's not already delivered",
         "tags": [
           "Orders"
@@ -1942,7 +1941,7 @@
     "/products/{id}": {
       "get": {
         "operationId": "get-products-{id}",
-        "summary": "Get product\r",
+        "summary": "Get product",
         "description": "Retrieves detailed product information by ID",
         "tags": [
           "Products"
@@ -2011,7 +2010,7 @@
       },
       "patch": {
         "operationId": "patch-products-{id}",
-        "summary": "Update product\r",
+        "summary": "Update product",
         "description": "Updates an existing product",
         "tags": [
           "Products"
@@ -2064,7 +2063,7 @@
       },
       "delete": {
         "operationId": "delete-products-{id}",
-        "summary": "Delete product\r",
+        "summary": "Delete product",
         "description": "Removes a product from the system",
         "tags": [
           "Products"
@@ -2100,7 +2099,7 @@
     "/upload": {
       "post": {
         "operationId": "post-upload",
-        "summary": "Upload image file\r",
+        "summary": "Upload image file",
         "description": "Uploads PNG or JPG image files with validation and metadata",
         "tags": [
           "Uploads"
@@ -2139,7 +2138,7 @@
     "/users": {
       "get": {
         "operationId": "get-users",
-        "summary": "Get users\r",
+        "summary": "Get users",
         "description": "Retrieve users",
         "tags": [
           "Users"
@@ -2148,9 +2147,7 @@
           {
             "in": "query",
             "name": "pagination",
-            "schema": {
-              "type": "object"
-            },
+            "schema": {},
             "required": false
           },
           {
@@ -2188,7 +2185,7 @@
     "/users/{id}": {
       "get": {
         "operationId": "get-users-{id}",
-        "summary": "Get user by ID\r",
+        "summary": "Get user by ID",
         "description": "Retrieves detailed user information",
         "tags": [
           "Users"
@@ -2237,7 +2234,7 @@
       },
       "patch": {
         "operationId": "patch-users-{id}",
-        "summary": "Update user\r",
+        "summary": "Update user",
         "description": "Updates user information",
         "tags": [
           "Users"
@@ -2290,7 +2287,7 @@
       },
       "delete": {
         "operationId": "delete-users-{id}",
-        "summary": "Delete user\r",
+        "summary": "Delete user",
         "description": "Deletes a user account",
         "tags": [
           "Users"
@@ -2326,7 +2323,7 @@
     "/users-paginated": {
       "get": {
         "operationId": "get-users-paginated",
-        "summary": "Get paginated users\r",
+        "summary": "Get paginated users",
         "description": "Retrieve users with cursor-based pagination using factory-generated schema",
         "tags": [
           "Users-paginated"

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,12 +14,14 @@
         "@babel/types": "^7.28.2",
         "commander": "^14.0.0",
         "fs-extra": "^11.3.1",
+        "js-yaml": "^4.1.0",
         "ora": "^8.2.0"
       },
       "bin": {
         "next-openapi-gen": "dist/index.js"
       },
       "devDependencies": {
+        "@types/js-yaml": "^4.0.9",
         "@types/node": "^24.3.0",
         "@vitest/ui": "^3.2.4",
         "conventional-changelog-cli": "^5.0.0",
@@ -1440,6 +1442,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true
+    },
     "node_modules/@types/node": {
       "version": "24.7.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.7.2.tgz",
@@ -1703,8 +1711,7 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/array-ify": {
       "version": "1.0.0",
@@ -3763,7 +3770,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },

--- a/tests/envelope-pattern.test.ts
+++ b/tests/envelope-pattern.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect } from "vitest";
+import { ZodSchemaConverter } from "../src/lib/zod-converter.js";
+import path from "path";
+import fs from "fs";
+
+describe("Envelope Pattern with Nested Schema References", () => {
+  it("should create $ref for nested schemas in envelope objects", () => {
+    // Create a temporary test file
+    const testDir = path.join(process.cwd(), "tests", "fixtures");
+    if (!fs.existsSync(testDir)) {
+      fs.mkdirSync(testDir, { recursive: true });
+    }
+
+    const testFile = path.join(testDir, "envelope-test.ts");
+    fs.writeFileSync(
+      testFile,
+      `
+import { z } from "zod";
+
+const userSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  email: z.string(),
+  createdAt: z.string(),
+});
+
+export const UserResponseEnvelope = z.object({
+  data: userSchema,
+});
+    `.trim()
+    );
+
+    try {
+      const converter = new ZodSchemaConverter(testDir);
+
+      // Convert the envelope schema
+      const envelopeSchema = converter.convertZodSchemaToOpenApi(
+        "UserResponseEnvelope"
+      );
+
+      expect(envelopeSchema).toBeDefined();
+      expect(envelopeSchema.type).toBe("object");
+      expect(envelopeSchema.properties).toBeDefined();
+      expect(envelopeSchema.properties.data).toBeDefined();
+
+      // The key fix: data property should have a $ref, not type: "object"
+      expect(envelopeSchema.properties.data.$ref).toBe(
+        "#/components/schemas/userSchema"
+      );
+      expect(envelopeSchema.properties.data.type).toBeUndefined();
+
+      // Check required fields - should only have "data" once
+      expect(envelopeSchema.required).toBeDefined();
+      expect(envelopeSchema.required).toEqual(["data"]);
+      expect(envelopeSchema.required.length).toBe(1);
+
+      // Verify the nested schema was also processed correctly
+      const schemas = converter.getProcessedSchemas();
+      expect(schemas.userSchema).toBeDefined();
+      expect(schemas.userSchema.type).toBe("object");
+      expect(schemas.userSchema.properties).toHaveProperty("id");
+      expect(schemas.userSchema.properties).toHaveProperty("name");
+      expect(schemas.userSchema.properties).toHaveProperty("email");
+      expect(schemas.userSchema.properties).toHaveProperty("createdAt");
+    } finally {
+      // Cleanup
+      if (fs.existsSync(testFile)) {
+        fs.unlinkSync(testFile);
+      }
+    }
+  });
+
+  it("should handle multiple levels of nested schemas", () => {
+    const testDir = path.join(process.cwd(), "tests", "fixtures");
+    if (!fs.existsSync(testDir)) {
+      fs.mkdirSync(testDir, { recursive: true });
+    }
+
+    const testFile = path.join(testDir, "nested-envelope-test.ts");
+    fs.writeFileSync(
+      testFile,
+      `
+import { z } from "zod";
+
+const addressSchema = z.object({
+  street: z.string(),
+  city: z.string(),
+  zipCode: z.string(),
+});
+
+const userSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  address: addressSchema,
+});
+
+export const UserResponseEnvelope = z.object({
+  data: userSchema,
+  meta: z.object({
+    timestamp: z.string(),
+  }),
+});
+    `.trim()
+    );
+
+    try {
+      const converter = new ZodSchemaConverter(testDir);
+
+      const envelopeSchema = converter.convertZodSchemaToOpenApi(
+        "UserResponseEnvelope"
+      );
+
+      expect(envelopeSchema).toBeDefined();
+
+      // Check the data property has a proper reference
+      expect(envelopeSchema.properties.data.$ref).toBe(
+        "#/components/schemas/userSchema"
+      );
+
+      // Check required array has no duplicates
+      const requiredSet = new Set(envelopeSchema.required);
+      expect(envelopeSchema.required.length).toBe(requiredSet.size);
+
+      // Verify all nested schemas were processed
+      const schemas = converter.getProcessedSchemas();
+      expect(schemas.userSchema).toBeDefined();
+      expect(schemas.addressSchema).toBeDefined();
+
+      // Verify userSchema also has proper reference to addressSchema
+      expect(schemas.userSchema.properties.address.$ref).toBe(
+        "#/components/schemas/addressSchema"
+      );
+    } finally {
+      if (fs.existsSync(testFile)) {
+        fs.unlinkSync(testFile);
+      }
+    }
+  });
+
+  it("should handle optional nested schemas", () => {
+    const testDir = path.join(process.cwd(), "tests", "fixtures");
+    if (!fs.existsSync(testDir)) {
+      fs.mkdirSync(testDir, { recursive: true });
+    }
+
+    const testFile = path.join(testDir, "optional-envelope-test.ts");
+    fs.writeFileSync(
+      testFile,
+      `
+import { z } from "zod";
+
+export const metaSchema = z.object({
+  page: z.number(),
+  total: z.number(),
+});
+
+export const DataEnvelope = z.object({
+  data: z.string(),
+  meta: metaSchema.optional(),
+});
+    `.trim()
+    );
+
+    try {
+      const converter = new ZodSchemaConverter(testDir);
+
+      const envelopeSchema = converter.convertZodSchemaToOpenApi("DataEnvelope");
+
+      expect(envelopeSchema).toBeDefined();
+
+      // Check required array - data should be required, meta should not
+      expect(envelopeSchema.required).toContain("data");
+      expect(envelopeSchema.required).not.toContain("meta");
+
+      // meta should still have a $ref even though it's optional
+      expect(envelopeSchema.properties.meta).toBeDefined();
+      expect(envelopeSchema.properties.meta.allOf).toBeDefined();
+      expect(envelopeSchema.properties.meta.allOf[0].$ref).toBe(
+        "#/components/schemas/metaSchema"
+      );
+    } finally {
+      if (fs.existsSync(testFile)) {
+        fs.unlinkSync(testFile);
+      }
+    }
+  });
+});

--- a/tests/non-exported-schema.test.ts
+++ b/tests/non-exported-schema.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { ZodSchemaConverter } from "../src/lib/zod-converter.js";
+import path from "path";
+import fs from "fs";
+
+describe("Non-exported nested schemas", () => {
+  it("should handle non-exported schemas referenced in exported schemas", () => {
+    const testDir = path.join(process.cwd(), "tests", "fixtures");
+    if (!fs.existsSync(testDir)) {
+      fs.mkdirSync(testDir, { recursive: true });
+    }
+
+    const testFile = path.join(testDir, "non-exported-test.ts");
+    fs.writeFileSync(
+      testFile,
+      `
+import { z } from "zod";
+
+const innerSchema = z.object({ 
+  foo: z.string(),
+  bar: z.number() 
+});
+
+export const ResponseEnvelope = z.object({ 
+  data: innerSchema 
+});
+    `.trim()
+    );
+
+    try {
+      const converter = new ZodSchemaConverter(testDir);
+      const envelopeSchema = converter.convertZodSchemaToOpenApi("ResponseEnvelope");
+
+      expect(envelopeSchema).toBeDefined();
+      expect(envelopeSchema.type).toBe("object");
+      expect(envelopeSchema.properties.data).toBeDefined();
+
+      // Should create a $ref even for non-exported schema
+      expect(envelopeSchema.properties.data.$ref).toBe(
+        "#/components/schemas/innerSchema"
+      );
+
+      // Verify the non-exported schema was also processed
+      const schemas = converter.getProcessedSchemas();
+      expect(schemas.innerSchema).toBeDefined();
+      expect(schemas.innerSchema.properties.foo).toBeDefined();
+      expect(schemas.innerSchema.properties.bar).toBeDefined();
+      
+      // Should not have duplicate required fields
+      expect(envelopeSchema.required).toEqual(["data"]);
+    } finally {
+      if (fs.existsSync(testFile)) {
+        fs.unlinkSync(testFile);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Description

When Zod schemas are wrapped in envelope objects (e.g., `z.object({ data: someSchema })`), `next-openapi-gen` doesn't create proper `$ref` references to the nested schema. Instead, it outputs a generic `type: "object"` with no properties, losing all type information.

**Example:**
```typescript
const userSchema = z.object({ id: z.string(), name: z.string() });
const UserResponseEnvelope = z.object({ data: userSchema });
```

**Generated (incorrect):**
```json
{
  "UserResponseEnvelope": {
    "properties": {
      "data": { "type": "object" }
    },
    "required": ["data", "data"]
  }
}
```

**Expected:**
```json
{
  "UserResponseEnvelope": {
    "properties": {
      "data": { "$ref": "#/components/schemas/userSchema" }
    },
    "required": ["data"]
  }
}
```

This breaks OpenAPI client code generation and makes API documentation incomplete.

## Type of Change

- [ ] ✨ **feat:** New feature
- [x] 🐛 **fix:** Bug fix
- [ ] 📝 **docs:** Documentation update
- [ ] ♻️ **refactor:** Code refactoring
- [ ] ⚡ **perf:** Performance improvement
- [ ] 💥 **Breaking change** (add `!` after type, e.g., `feat!:`)

## Reproduction Steps

1. Create a Zod schema:
```typescript
const innerSchema = z.object({ 
  foo: z.string(),
  bar: z.number() 
});

export const ResponseEnvelope = z.object({ 
  data: innerSchema 
});
```

2. Reference in route JSDoc:
```typescript
/**
 * @response ResponseEnvelope
 * @openapi
 */
export async function GET() {
  // ...
}
```

3. Generate OpenAPI:
```bash
next-openapi-gen generate
```

4. Check the generated `openapi.json` - the `ResponseEnvelope` will have `data: { "type": "object" }` instead of `data: { "$ref": "#/components/schemas/innerSchema" }`

## Environment

- `next-openapi-gen`: `0.8.6` (also tested with `0.8.2`)
- `zod`: `3.x`
- `next`: `15.x`

## Impact

- ❌ OpenAPI clients can't generate proper types for response envelopes
- ❌ API documentation is incomplete
- ❌ Duplicate fields in `required` arrays
- ✅ Actual API runtime works fine (this is only a documentation/codegen issue)

## Additional Notes

- The nested schema (`innerSchema`) IS correctly generated with all properties in the OpenAPI spec
- Only the wrapper/envelope schemas fail to create proper references
- This severely limits the usefulness of envelope patterns (common in REST APIs) where responses are wrapped in structures like `{ data: T }`, `{ data: T, meta: M }`, etc.
- No known workaround except manually patching the generated `openapi.json`

## Checklist

- [x] Code follows project style
- [x] Tested locally
- [x] Documentation updated (if needed)

---

## ⚠️ PR Title Format Required

Your **PR title** must follow [Conventional Commits](https://www.conventionalcommits.org/):

### ✅ Good Examples

```
fix: generate $ref for nested Zod schemas in envelope objects
fix: resolve missing schema references in wrapped objects
fix: correct duplicate required fields in envelope schemas
```

### ❌ Bad Examples

```
Fixed schema generation
Update OpenAPI generator
Improve envelope handling
```

**Why?** We use squash merge - your PR title becomes the commit message and is used for:
- 📊 Auto-generating changelogs
- 🏷️ Version bumping (`feat:` = minor, `fix:` = patch)
- 📖 Clean git history

See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.

---

Thanks for contributing! 🚀
