### PR TITLE
fix: disable SSR for swagger-ui-react in latest version

### DIFF
--- a/src/components/swagger.ts
+++ b/src/components/swagger.ts
@@ -8,7 +8,6 @@ import "swagger-ui-react/swagger-ui.css";
 import dynamic from "next/dynamic";
 
 const SwaggerUI = dynamic(() => import("swagger-ui-react"), {
-  ssr: false,
   loading: () => <p>Loading Component...</p>,
 });
 


### PR DESCRIPTION
## Description

Disable SSR for swagger-ui-react in latest version.

## Type of Change

- [x] ✨ **feat:** New feature

## Checklist

- [x] Code follows project style
- [x] Tested locally
- [x] Documentation updated (if needed)

Closes #64 