### PR TITLE
feat: add @queryParams as alternative to @params to prevent prettier auto-fixing

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ export async function POST(request: NextRequest) {
 | `@description`         | Endpoint description                                                                                                     |
 | `@operationId`         | Custom operation ID (overrides auto-generated ID)                                                                        |
 | `@pathParams`          | Path parameters type/schema                                                                                              |
-| `@params`              | Query parameters type/schema                                                                                             |
+| `@params`              | Query parameters type/schema (use `@queryParams` if you have prettier-plugin-jsdoc conflicts)                           |
 | `@body`                | Request body type/schema                                                                                                 |
 | `@bodyDescription`     | Request body description                                                                                                 |
 | `@response`            | Response type/schema with optional code and description (`User`, `201:User`, `User:Description`, `201:User:Description`) |

--- a/examples/next15-app-sandbox/package-lock.json
+++ b/examples/next15-app-sandbox/package-lock.json
@@ -27,7 +27,7 @@
       }
     },
     "../..": {
-      "version": "0.8.4",
+      "version": "0.9.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/examples/next15-app-sandbox/public/openapi.json
+++ b/examples/next15-app-sandbox/public/openapi.json
@@ -290,6 +290,76 @@
           "name"
         ]
       },
+      "SearchQueryParams": {
+        "type": "object",
+        "properties": {
+          "q": {
+            "type": "string",
+            "description": "Search query"
+          },
+          "page": {
+            "type": "number",
+            "nullable": true,
+            "description": "Page number"
+          },
+          "limit": {
+            "type": "number",
+            "nullable": true,
+            "description": "Items per page"
+          },
+          "sort": {
+            "type": "string",
+            "enum": [
+              "asc",
+              "desc"
+            ],
+            "nullable": true,
+            "description": "Sort order"
+          }
+        },
+        "required": [
+          "q"
+        ]
+      },
+      "SearchResponse": {
+        "type": "object",
+        "properties": {
+          "results": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "Result ID"
+                },
+                "title": {
+                  "type": "string",
+                  "description": "Result title"
+                },
+                "score": {
+                  "type": "number",
+                  "description": "Relevance score"
+                }
+              },
+              "required": [
+                "id",
+                "title",
+                "score"
+              ]
+            },
+            "description": "Search results"
+          },
+          "total": {
+            "type": "number",
+            "description": "Total results found"
+          }
+        },
+        "required": [
+          "results",
+          "total"
+        ]
+      },
       "GetUserProfilePathParams": {
         "type": "object",
         "properties": {
@@ -683,6 +753,80 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        }
+      }
+    },
+    "/test-query-params": {
+      "get": {
+        "operationId": "get-test-query-params",
+        "summary": "Search endpoint with @queryParams tag\r",
+        "description": "Test endpoint to verify @queryParams works (to avoid prettier-plugin-jsdoc conflicts)",
+        "tags": [
+          "Test-query-params"
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "q",
+            "schema": {
+              "type": "string",
+              "description": "Search query"
+            },
+            "required": false,
+            "description": "Search query"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "number",
+              "description": "Page number"
+            },
+            "required": false,
+            "description": "Page number"
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "number",
+              "description": "Items per page"
+            },
+            "required": false,
+            "description": "Items per page"
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "description": "Sort order"
+            },
+            "required": false,
+            "description": "Sort order"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchResponse"
                 }
               }
             }

--- a/examples/next15-app-sandbox/src/app/api/test-query-params/route.ts
+++ b/examples/next15-app-sandbox/src/app/api/test-query-params/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+export const SearchQueryParams = z.object({
+  q: z.string().describe("Search query"),
+  page: z.number().optional().describe("Page number"),
+  limit: z.number().optional().describe("Items per page"),
+  sort: z.enum(["asc", "desc"]).optional().describe("Sort order"),
+});
+
+export const SearchResponse = z.object({
+  results: z.array(z.object({
+    id: z.string().describe("Result ID"),
+    title: z.string().describe("Result title"),
+    score: z.number().describe("Relevance score"),
+  })).describe("Search results"),
+  total: z.number().describe("Total results found"),
+});
+
+/**
+ * Search endpoint with @queryParams tag
+ * @description Test endpoint to verify @queryParams works (to avoid prettier-plugin-jsdoc conflicts)
+ * @queryParams SearchQueryParams
+ * @response SearchResponse
+ * @openapi
+ */
+export async function GET(request: NextRequest) {
+  return NextResponse.json({
+    results: [
+      {
+        id: "result-1",
+        title: "Example Result",
+        score: 0.95,
+      },
+    ],
+    total: 1,
+  });
+}

--- a/examples/next15-app-zod/public/openapi.json
+++ b/examples/next15-app-zod/public/openapi.json
@@ -1925,7 +1925,7 @@
     "/extended": {
       "get": {
         "operationId": "get-extended",
-        "summary": "Get nested schema example",
+        "summary": "Get nested schema example\r",
         "description": "Retrieve nested schema data to test $ref generation",
         "tags": [
           "Extended"
@@ -1952,7 +1952,7 @@
       },
       "post": {
         "operationId": "post-extended",
-        "summary": "Create extended schema",
+        "summary": "Create extended schema\r",
         "description": "Create a new item with extended schema to test .extend() functionality",
         "tags": [
           "Extended"
@@ -1989,7 +1989,7 @@
       },
       "put": {
         "operationId": "put-extended",
-        "summary": "Update double extended schema",
+        "summary": "Update double extended schema\r",
         "description": "Update with double extended schema to test deep inheritance",
         "tags": [
           "Extended"

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -105,8 +105,9 @@ export function extractJSDocComments(path: NodePath): DataTypes {
         }
       }
 
-      if (commentValue.includes("@params")) {
-        paramsType = extractTypeFromComment(commentValue, "@params");
+      if (commentValue.includes("@params") || commentValue.includes("@queryParams")) {
+        paramsType = extractTypeFromComment(commentValue, "@queryParams") ||
+                     extractTypeFromComment(commentValue, "@params");
       }
 
       if (commentValue.includes("@pathParams")) {
@@ -204,9 +205,10 @@ export function extractTypeFromComment(
   tag: string
 ): string {
   // Updated regex to support generic types with angle brackets and array brackets
+  // Use multiline mode (m flag) to match tag at start of line (after optional * from JSDoc)
   return (
     commentValue
-      .match(new RegExp(`${tag}\\s*\\s*([\\w<>,\\s\\[\\]]+)`))?.[1]
+      .match(new RegExp(`^\\s*\\*?\\s*${tag}\\s+([\\w<>,\\s\\[\\]]+)`, 'm'))?.[1]
       ?.trim() || ""
   );
 }


### PR DESCRIPTION
## Description

Add @queryParams as alternative to @params to prevent prettier auto-fixing

## Type of Change

- [x] ✨ **feat:** New feature

## Checklist

- [x] Code follows project style
- [x] Tested locally
- [x] Documentation updated (if needed)

Closes #72 