### PR TITLE
fix: resolve enum identifier references in z.enum()

### DIFF
--- a/packages/openapi-core/src/schema/zod/node-helpers.ts
+++ b/packages/openapi-core/src/schema/zod/node-helpers.ts
@@ -9,6 +9,7 @@ type PrimitiveHelperContext = {
   processObject: (node: t.CallExpression) => OpenApiSchema;
   ensureSchema: (schemaName: string) => void;
   getReferenceSchema: (schemaName: string) => OpenApiSchema;
+  resolveEnumValues?: (name: string) => (string | number)[] | null;
 };
 
 function isProcessableZodNode(
@@ -362,6 +363,7 @@ export function processZodPrimitiveNode(
       schema = { type: "array", items: itemsType };
       break;
     }
+    case "nativeEnum":
     case "enum":
       if (node.arguments.length > 0 && t.isArrayExpression(node.arguments[0])) {
         const enumValues = node.arguments[0].elements
@@ -389,6 +391,18 @@ export function processZodPrimitiveNode(
                 enum: enumValues,
               }
             : { type: "string" };
+      } else if (
+        node.arguments.length > 0 &&
+        t.isIdentifier(node.arguments[0]) &&
+        context.resolveEnumValues
+      ) {
+        const resolved = context.resolveEnumValues(node.arguments[0].name);
+        if (resolved && resolved.length > 0) {
+          const valueType = typeof resolved[0] === "number" ? "number" : "string";
+          schema = { type: valueType, enum: resolved };
+        } else {
+          schema = { type: "string" };
+        }
       } else {
         schema = { type: "string" };
       }

--- a/packages/openapi-core/src/schema/zod/zod-converter.ts
+++ b/packages/openapi-core/src/schema/zod/zod-converter.ts
@@ -1272,7 +1272,98 @@ export class ZodSchemaConverter {
       getReferenceSchema: (schemaName) => ({
         $ref: `#/components/schemas/${this.getSchemaReferenceName(schemaName)}`,
       }),
+      resolveEnumValues: (name) => this.resolveEnumValues(name),
     });
+  }
+
+  /**
+   * Resolve enum values from a TS enum declaration or an `as const` object by identifier name.
+   * Searches the current file first, then follows imports.
+   */
+  private resolveEnumValues(name: string): (string | number)[] | null {
+    const extractFromAST = (ast: t.File): (string | number)[] | null => {
+      let result: (string | number)[] | null = null;
+
+      traverse(ast, {
+        TSEnumDeclaration: (nodePath: NodePath<t.TSEnumDeclaration>) => {
+          if (result) return;
+          if (nodePath.node.id && t.isIdentifier(nodePath.node.id, { name })) {
+            const values: (string | number)[] = [];
+            for (const member of nodePath.node.members) {
+              if (t.isTSEnumMember(member) && member.initializer) {
+                if (t.isStringLiteral(member.initializer)) {
+                  values.push(member.initializer.value);
+                } else if (t.isNumericLiteral(member.initializer)) {
+                  values.push(member.initializer.value);
+                }
+              }
+            }
+            if (values.length > 0) {
+              result = values;
+            }
+          }
+        },
+        VariableDeclarator: (nodePath: NodePath<t.VariableDeclarator>) => {
+          if (result) return;
+          if (!t.isIdentifier(nodePath.node.id, { name }) || !nodePath.node.init) return;
+
+          // Unwrap `as const` / `satisfies` wrappers
+          let initNode: t.Node = nodePath.node.init;
+          if (t.isTSAsExpression(initNode) || t.isTSSatisfiesExpression(initNode)) {
+            initNode = initNode.expression;
+          }
+
+          if (t.isObjectExpression(initNode)) {
+            const values: (string | number)[] = [];
+            for (const prop of initNode.properties) {
+              if (t.isObjectProperty(prop)) {
+                if (t.isStringLiteral(prop.value)) {
+                  values.push(prop.value.value);
+                } else if (t.isNumericLiteral(prop.value)) {
+                  values.push(prop.value.value);
+                }
+              }
+            }
+            if (values.length > 0) {
+              result = values;
+            }
+          } else if (t.isArrayExpression(initNode)) {
+            const values: (string | number)[] = [];
+            for (const element of initNode.elements) {
+              if (t.isStringLiteral(element)) {
+                values.push(element.value);
+              } else if (t.isNumericLiteral(element)) {
+                values.push(element.value);
+              }
+            }
+            if (values.length > 0) {
+              result = values;
+            }
+          }
+        },
+      });
+
+      return result;
+    };
+
+    // Search in current file first
+    if (this.currentAST) {
+      const values = extractFromAST(this.currentAST);
+      if (values) return values;
+    }
+
+    // Follow imports
+    if (this.currentImports && this.currentFilePath && this.currentImports[name]) {
+      const resolvedPath = this.resolveImportPath(this.currentFilePath, this.currentImports[name]);
+      if (resolvedPath) {
+        const importedAST = this.parseFileWithCache(resolvedPath);
+        if (importedAST) {
+          return extractFromAST(importedAST);
+        }
+      }
+    }
+
+    return null;
   }
 
   /**

--- a/tests/unit/schema/zod/node-helpers.test.ts
+++ b/tests/unit/schema/zod/node-helpers.test.ts
@@ -270,4 +270,66 @@ describe("Zod node helpers", () => {
     });
     expect(ensuredSchemas).toEqual(["UserSchema"]);
   });
+
+  it("resolves z.enum with identifier via resolveEnumValues callback", () => {
+    const context = {
+      processNode,
+      processObject: () => ({ type: "object" as const }),
+      ensureSchema: () => {},
+      getReferenceSchema: () => ({}),
+      resolveEnumValues: (name: string) => {
+        if (name === "Color") return ["red", "green", "blue"];
+        if (name === "STATUS") return ["active", "inactive", "pending"];
+        return null;
+      },
+    };
+
+    // TS enum identifier
+    expect(
+      processZodPrimitiveNode(getFirstInitializer("z.enum(Color)") as t.CallExpression, context),
+    ).toEqual({ type: "string", enum: ["red", "green", "blue"] });
+
+    // as const object identifier
+    expect(
+      processZodPrimitiveNode(getFirstInitializer("z.enum(STATUS)") as t.CallExpression, context),
+    ).toEqual({ type: "string", enum: ["active", "inactive", "pending"] });
+
+    // z.nativeEnum also works
+    expect(
+      processZodPrimitiveNode(
+        getFirstInitializer("z.nativeEnum(Color)") as t.CallExpression,
+        context,
+      ),
+    ).toEqual({ type: "string", enum: ["red", "green", "blue"] });
+  });
+
+  it("falls back to { type: 'string' } for unresolvable enum identifiers", () => {
+    const context = {
+      processNode,
+      processObject: () => ({ type: "object" as const }),
+      ensureSchema: () => {},
+      getReferenceSchema: () => ({}),
+      resolveEnumValues: () => null,
+    };
+
+    expect(
+      processZodPrimitiveNode(
+        getFirstInitializer("z.enum(UnknownEnum)") as t.CallExpression,
+        context,
+      ),
+    ).toEqual({ type: "string" });
+  });
+
+  it("falls back to { type: 'string' } for enum identifier without resolveEnumValues", () => {
+    const context = {
+      processNode,
+      processObject: () => ({ type: "object" as const }),
+      ensureSchema: () => {},
+      getReferenceSchema: () => ({}),
+    };
+
+    expect(
+      processZodPrimitiveNode(getFirstInitializer("z.enum(SomeEnum)") as t.CallExpression, context),
+    ).toEqual({ type: "string" });
+  });
 });

--- a/tests/unit/schema/zod/zod-converter.test.ts
+++ b/tests/unit/schema/zod/zod-converter.test.ts
@@ -344,4 +344,132 @@ describe("ZodSchemaConverter", () => {
       required: ["id"],
     });
   });
+
+  it("resolves z.enum with TS enum identifiers", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "nxog-zod-converter-enum-ref-"));
+    roots.push(root);
+
+    fs.writeFileSync(
+      path.join(root, "schemas.ts"),
+      [
+        'import { z } from "zod";',
+        "",
+        "enum Color {",
+        '  Red = "red",',
+        '  Green = "green",',
+        '  Blue = "blue",',
+        "}",
+        "",
+        "export const itemSchema = z.object({",
+        "  color: z.enum(Color),",
+        "});",
+      ].join("\n"),
+    );
+
+    const converter = new ZodSchemaConverter(root);
+    converter.convertZodSchemaToOpenApi("itemSchema");
+
+    expect(converter.zodSchemas.itemSchema).toEqual({
+      type: "object",
+      properties: {
+        color: { type: "string", enum: ["red", "green", "blue"] },
+      },
+      required: ["color"],
+    });
+  });
+
+  it("resolves z.enum with as-const object identifiers", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "nxog-zod-converter-const-ref-"));
+    roots.push(root);
+
+    fs.writeFileSync(
+      path.join(root, "schemas.ts"),
+      [
+        'import { z } from "zod";',
+        "",
+        "const STATUS = {",
+        '  Active: "active",',
+        '  Inactive: "inactive",',
+        '  Pending: "pending",',
+        "} as const;",
+        "",
+        "export const taskSchema = z.object({",
+        "  status: z.enum(STATUS),",
+        "});",
+      ].join("\n"),
+    );
+
+    const converter = new ZodSchemaConverter(root);
+    converter.convertZodSchemaToOpenApi("taskSchema");
+
+    expect(converter.zodSchemas.taskSchema).toEqual({
+      type: "object",
+      properties: {
+        status: { type: "string", enum: ["active", "inactive", "pending"] },
+      },
+      required: ["status"],
+    });
+  });
+
+  it("resolves z.enum with as-const array identifiers", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "nxog-zod-converter-arr-ref-"));
+    roots.push(root);
+
+    fs.writeFileSync(
+      path.join(root, "schemas.ts"),
+      [
+        'import { z } from "zod";',
+        "",
+        'const ROLES = ["admin", "editor", "viewer"] as const;',
+        "",
+        "export const roleSchema = z.object({",
+        "  role: z.enum(ROLES),",
+        "});",
+      ].join("\n"),
+    );
+
+    const converter = new ZodSchemaConverter(root);
+    converter.convertZodSchemaToOpenApi("roleSchema");
+
+    expect(converter.zodSchemas.roleSchema).toEqual({
+      type: "object",
+      properties: {
+        role: { type: "string", enum: ["admin", "editor", "viewer"] },
+      },
+      required: ["role"],
+    });
+  });
+
+  it("resolves z.enum with numeric TS enum identifiers", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "nxog-zod-converter-num-enum-"));
+    roots.push(root);
+
+    fs.writeFileSync(
+      path.join(root, "schemas.ts"),
+      [
+        'import { z } from "zod";',
+        "",
+        "enum HttpStatus {",
+        "  OK = 200,",
+        "  NotFound = 404,",
+        "  ServerError = 500,",
+        "}",
+        "",
+        "export const responseSchema = z.object({",
+        "  status: z.enum(HttpStatus),",
+        "});",
+      ].join("\n"),
+    );
+
+    const converter = new ZodSchemaConverter(root);
+    converter.convertZodSchemaToOpenApi("responseSchema");
+
+    expect(converter.zodSchemas.responseSchema).toEqual({
+      type: "object",
+      properties: {
+        status: { type: "number", enum: [200, 404, 500] },
+      },
+      required: ["status"],
+    });
+  });
 });


### PR DESCRIPTION
# Pull Request

## Description

`z.nativeEnum()` has previously been deprecated merged into `z.enum()` and documents enum/const-object arguments as supported (see the @deprecated notice on nativeEnum and the schema-use-enums reference in the next-openapi-gen skills directory). However, `z.enum()` and `z.nativeEnum()` silently produce `{ type: "string" }` with no `enum` values when the argument is an identifier reference instead of an inline literal. This is because the OpenAPI schema builder only handled `ArrayExpression` and `ObjectExpression` AST nodes — an `Identifier` fell through to the default branch.

This fix adds identifier resolution for enum arguments, supporting:
  - TS enums (`enum Color { Red = "red" }`)
  - `as const` objects (`const X = { A: "a" } as const`)
  - `as const` arrays (`const X = ["a", "b"] as const`)
  - `satisfies` wrappers
  - Both string and numeric values
  - Cross-file resolution via import tracking

## Type of Change

- [ ] ✨ **feat:** New feature
- [x] � **fix:** Bug fix
- [ ] 📝 **docs:** Documentation update
- [ ] ♻️ **refactor:** Code refactoring
- [ ] ⚡ **perf:** Performance improvement
- [ ] 💥 **Breaking change** (add `!` after type, e.g., `feat!:`)

## Checklist

- [x] `pnpm check` passes
- [x] Tested locally (`pnpm test` and `pnpm build` when relevant)
- [x] Documentation updated (if needed)