### PR TITLE
fix: detect typed const app route handlers

### DIFF
--- a/packages/openapi-framework-next/src/routes/app-router-strategy.ts
+++ b/packages/openapi-framework-next/src/routes/app-router-strategy.ts
@@ -44,7 +44,7 @@ export class AppRouterStrategy implements RouterStrategy {
       return false;
     }
 
-    return /export\s+(?:async\s+)?function\s+(GET|POST|PUT|PATCH|DELETE)\b|export\s+const\s+(GET|POST|PUT|PATCH|DELETE)\s*=/.test(
+    return /export\s+(?:async\s+)?function\s+(GET|POST|PUT|PATCH|DELETE)\b|export\s+const\s+(GET|POST|PUT|PATCH|DELETE)\b(?:\s*:\s*(?:=>|[^=;])+)?\s*=(?!=|>)/.test(
       content,
     );
   }

--- a/tests/unit/routes/app-router-strategy.test.ts
+++ b/tests/unit/routes/app-router-strategy.test.ts
@@ -95,6 +95,47 @@ describe("AppRouterStrategy", () => {
     expect(strategy.precheckFile(routeFile)).toBe(false);
   });
 
+  it.each([
+    [
+      "without context",
+      `export const GET: RouteHandler = async (_request) => {
+        return Response.json({ ok: true });
+      };`,
+    ],
+    [
+      "with context",
+      `export const GET: RouteHandler = async (_request, _context) => {
+        return Response.json({ ok: true });
+      };`,
+    ],
+    [
+      "with typed path params",
+      `export const GET: RouteHandler<PathParams> = async (_request, _context) => {
+        return Response.json({ ok: true });
+      };`,
+    ],
+  ])("precheckFile accepts typed const route handlers %s", (_label, handlerSource) => {
+    strategy = new AppRouterStrategy(baseConfig);
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "nxog-app-precheck-typed-const-"));
+    roots.push(root);
+    const routeFile = path.join(root, "route.ts");
+    fs.writeFileSync(
+      routeFile,
+      `
+      type RouteHandler<TParams = unknown> = (
+        request: Request,
+        context: { params: Promise<TParams> },
+      ) => Promise<Response>;
+
+      type PathParams = { id: string };
+
+      ${handlerSource}
+      `,
+    );
+
+    expect(strategy.precheckFile(routeFile)).toBe(true);
+  });
+
   it("reuses readFile cache across repeated precheckFile calls", () => {
     strategy = new AppRouterStrategy(baseConfig);
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "nxog-app-readfile-cache-"));


### PR DESCRIPTION
# Pull Request

## Description

Allow the App Router precheck to recognize exported const handlers with TypeScript annotations, including generic route handler aliases. This keeps typed Next.js route handler declarations from being skipped before the AST-based route extraction runs.

Add focused regression coverage for a typed const GET handler so future matcher changes preserve this supported route style.

Allow the Next.js App Router precheck to recognize exported const route handlers that include TypeScript annotations. Before this change, a valid typed handler like this could be skipped before AST route extraction ran:

```typescript
export const GET: RouteHandler = async (request) => {
  // ...
};
```

## Type of Change

- [ ] ✨ **feat:** New feature
- [x] � **fix:** Bug fix
- [ ] 📝 **docs:** Documentation update
- [ ] ♻️ **refactor:** Code refactoring
- [ ] ⚡ **perf:** Performance improvement
- [ ] 💥 **Breaking change** (add `!` after type, e.g., `feat!:`)

## Checklist

- [x] `pnpm check` passes
- [x] Tested locally (`pnpm test` and `pnpm build` when relevant)
- [] Documentation updated (if needed)

---

## ⚠️ PR Title Format Required

Your **PR title** must follow [Conventional Commits](https://www.conventionalcommits.org/):

### ✅ Good Examples

```text
feat: add support for multiple schema types
fix: resolve path parameter detection issue
docs: update configuration examples
```

### ❌ Bad Examples

```text
Added feature
Fixed bug
Update README
```

**Why?** We use squash merge - your PR title becomes the commit message and is used for:

- 📊 Auto-generating changelogs
- 🏷️ Version bumping (`feat:` = minor, `fix:` = patch)
- 📖 Clean git history

See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.

---

Thanks for contributing! 🚀
