### PR TITLE
fix(schema): resolve types from node_modules/workspace packages via TypeScript checker fallback

### DIFF
--- a/packages/openapi-core/src/schema/typescript/schema-processor.ts
+++ b/packages/openapi-core/src/schema/typescript/schema-processor.ts
@@ -354,8 +354,22 @@ export class SchemaProcessor {
 
       const typeDefEntry = this.typeDefinitions[typeName.toString()];
       if (!typeDefEntry) {
-        // Emit a diagnostic so consumers can debug unresolved identifiers instead of silently
-        // falling back to an empty schema.
+        // The type is not defined in any of the scanned schema dirs. It may come from
+        // node_modules or a directory not covered by schemaDir (e.g. a shared package
+        // whose types are `z.infer<typeof schema>` aliases). As a fallback, look for any
+        // scanned file that imports this type and use the TypeScript language service to
+        // resolve it — the compiler already knows the full shape of imported types.
+        const contextFile = this.findFileImportingType(typeName);
+        if (contextFile) {
+          logger.debug(
+            `resolveType: "${typeName}" not in schema dirs; attempting TypeScript checker fallback via ${contextFile}`,
+          );
+          const checkerSchema = this.resolveTypeWithTypeScriptChecker(typeName, contextFile);
+          if (checkerSchema && Object.keys(checkerSchema).length > 0) {
+            this.openapiDefinitions[typeName] = checkerSchema;
+            return checkerSchema;
+          }
+        }
         logger.debug(
           `resolveType: no TypeScript definition found for "${typeName}" in ${this.currentFilePath}; returning empty schema`,
         );
@@ -625,6 +639,20 @@ export class SchemaProcessor {
     return null;
   }
 
+  /**
+   * Return the path of the first scanned file that imports `typeName`, or `null` when none is
+   * found. Used as a fallback context for {@link resolveTypeWithTypeScriptChecker} when the type
+   * is not defined in any schema-dir file (e.g. comes from node_modules or a shared package).
+   */
+  private findFileImportingType(typeName: string): string | null {
+    for (const [filePath, imports] of Object.entries(this.importMap)) {
+      if (Object.prototype.hasOwnProperty.call(imports, typeName)) {
+        return filePath;
+      }
+    }
+    return null;
+  }
+
   private shouldUseTypeScriptChecker(node: t.Node): boolean {
     return (
       t.isTSConditionalType(node) ||
@@ -737,7 +765,21 @@ export class SchemaProcessor {
       return { type: "object" };
     }
 
-    seen.add(seenKey);
+    // Only track non-trivial types in `seen`. Primitives (string, number, boolean, null, etc.)
+    // may appear on multiple properties of the same object without being circular — adding them
+    // to `seen` would incorrectly turn their second occurrence into `{ type: "object" }`.
+    if (
+      !(
+        type.flags &
+        (primitiveLikeFlags |
+          ts.TypeFlags.Any |
+          ts.TypeFlags.Never |
+          ts.TypeFlags.Unknown |
+          ts.TypeFlags.Void)
+      )
+    ) {
+      seen.add(seenKey);
+    }
 
     if (type.isStringLiteral()) {
       return { type: "string", enum: [type.value] };

--- a/tests/fixtures/external-type-resolution/shared-types.ts
+++ b/tests/fixtures/external-type-resolution/shared-types.ts
@@ -1,0 +1,18 @@
+/**
+ * Simulates types defined in a shared package (e.g. node_modules or a workspace
+ * package outside of the configured schemaDir). The schema processor cannot scan
+ * this file directly — it resolves the type via the TypeScript checker using a
+ * route file that imports it as context.
+ */
+
+export interface ExternalUser {
+  id: number;
+  name: string;
+  email: string;
+}
+
+export interface ExternalApiError {
+  message: string;
+  code?: string;
+  statusCode: number;
+}

--- a/tests/fixtures/external-type-resolution/src/route.ts
+++ b/tests/fixtures/external-type-resolution/src/route.ts
@@ -1,0 +1,15 @@
+/**
+ * Simulates an API route file inside schemaDir that imports types from an
+ * external package (outside schemaDir). next-openapi-gen scans this file as
+ * part of the schemaDir crawl, so the import is tracked in importMap. When a
+ * JSDoc annotation references ExternalUser or ExternalApiError, the schema
+ * processor falls back to the TypeScript checker using this file as context.
+ *
+ * @openapi
+ * @response ExternalUser 200 Success
+ * @response ExternalApiError 400 Bad Request
+ */
+
+import { ExternalUser, ExternalApiError } from "../shared-types";
+
+export type { ExternalUser, ExternalApiError };

--- a/tests/unit/schema/typescript/schema-processor.test.ts
+++ b/tests/unit/schema/typescript/schema-processor.test.ts
@@ -473,4 +473,33 @@ describe("SchemaProcessor", () => {
     expect((processor as any).extractFunctionParameters(anonymousNode)).toHaveLength(1);
     expect((processor as any).extractFunctionParameters(t.identifier("noop"))).toEqual([]);
   });
+
+  it("resolves types from outside schemaDir via TypeScript checker fallback", () => {
+    // Regression: types defined in node_modules or a shared workspace package that is not
+    // covered by schemaDir were silently resolved to `{}`. The fix uses the importMap to
+    // find a scanned file that imports the type, then delegates to resolveTypeWithTypeScriptChecker.
+    const fixtureDir = path.resolve(__dirname, "../../../fixtures/external-type-resolution");
+    // schemaDir is only "src/" — shared-types.ts lives at the fixture root (outside src/)
+    const schemaDir = path.join(fixtureDir, "src");
+    const processor = new SchemaProcessor(schemaDir, "typescript");
+
+    const userSchema = processor.findSchemaDefinition("ExternalUser", "response");
+    expect(userSchema).toMatchObject({
+      type: "object",
+      properties: expect.objectContaining({
+        id: expect.objectContaining({ type: expect.stringMatching(/number|integer/) }),
+        name: { type: "string" },
+        email: { type: "string" },
+      }),
+    });
+
+    const errorSchema = processor.findSchemaDefinition("ExternalApiError", "response");
+    expect(errorSchema).toMatchObject({
+      type: "object",
+      properties: expect.objectContaining({
+        message: { type: "string" },
+        statusCode: expect.objectContaining({ type: expect.stringMatching(/number|integer/) }),
+      }),
+    });
+  });
 });


### PR DESCRIPTION
## Description

When a route annotation references a type defined **outside `schemaDir`** (e.g. in `node_modules` or a shared workspace package), the schema processor could not find it during the directory scan and silently returned `{}`.

**Root cause:** `resolveType` bailed out immediately when `typeDefinitions[typeName]` was empty — the TypeScript-checker path was never reached for external types.

**Fix:** Two changes in `schema-processor.ts`:
1. After the "not in schema dirs" bail-out, search `importMap` for any scanned file that imports the requested type and use it as context for `resolveTypeWithTypeScriptChecker` — which can follow the import chain and resolve the full type shape including `z.infer<typeof schema>` aliases.
2. Exclude primitive types (`string`, `number`, `boolean`, etc.) from the `seen` cycle-guard set — they are never circular, and being tracked caused a second property with the same primitive type in one interface to resolve as `{ type: "object" }` instead of the correct primitive schema.

**Before:** `ApiError` (defined outside `schemaDir`) → `{}` ❌
**After:** `ApiError` → `{ type: "object", properties: { message: { type: "string" }, code: { type: "string" } }, required: ["message"] }` ✅

New fixture and test in `tests/fixtures/external-type-resolution/` cover both fixes. All 700 existing tests continue to pass.

## Type of Change

- [ ] ✨ **feat:** New feature
- [x] 🐛 **fix:** Bug fix
- [ ] 📝 **docs:** Documentation update
- [ ] ♻️ **refactor:** Code refactoring
- [ ] ⚡ **perf:** Performance improvement
- [ ] 💥 **Breaking change** (add `!` after type, e.g., `feat!:`)

## Checklist

- [x] `pnpm check` passes
- [x] Tested locally (`pnpm test:unit` — all tests pass; `pnpm build` successful)
- [ ] Documentation updated (if needed)