### PR TITLE
fix(zod): add z.strictObject support in schema processor

### DIFF
--- a/apps/next-app-drizzle-zod/public/openapi.json
+++ b/apps/next-app-drizzle-zod/public/openapi.json
@@ -856,7 +856,8 @@
             "maxLength": 100,
             "description": "Author display name"
           }
-        }
+        },
+        "required": []
       },
       "UpdatePostSchema": {
         "type": "object",
@@ -886,7 +887,8 @@
             "type": "boolean",
             "description": "Publication status"
           }
-        }
+        },
+        "required": []
       }
     },
     "responses": {

--- a/packages/openapi-core/src/schema/zod/node-helpers.ts
+++ b/packages/openapi-core/src/schema/zod/node-helpers.ts
@@ -728,8 +728,12 @@ export function processZodPrimitiveNode(
       };
       break;
     }
+    case "strictObject":
     case "object":
       schema = node.arguments.length > 0 ? context.processObject(node) : { type: "object" };
+      if (zodType === "strictObject") {
+        schema.additionalProperties = false;
+      }
       break;
     case "templateLiteral":
       schema = { type: "string" };

--- a/packages/openapi-core/src/schema/zod/runtime-exporter.ts
+++ b/packages/openapi-core/src/schema/zod/runtime-exporter.ts
@@ -112,6 +112,10 @@ export class ZodRuntimeExporter {
         return node.arguments[0] && isProcessableNode(node.arguments[0])
           ? z.array(this.buildSchema(node.arguments[0]) ?? z.unknown())
           : z.array(z.unknown());
+      case "strictObject": {
+        const base = this.buildObject(node);
+        return base && typeof (base as any).strict === "function" ? (base as any).strict() : base;
+      }
       case "object":
         return this.buildObject(node);
       case "record":

--- a/packages/openapi-core/src/schema/zod/zod-converter.ts
+++ b/packages/openapi-core/src/schema/zod/zod-converter.ts
@@ -978,8 +978,12 @@ export class ZodSchemaConverter {
     ) {
       const methodName = node.callee.property.name;
 
-      if (methodName === "object" && node.arguments.length > 0) {
-        return this.processZodObject(node);
+      if ((methodName === "object" || methodName === "strictObject") && node.arguments.length > 0) {
+        const schema = this.processZodObject(node);
+        if (methodName === "strictObject") {
+          schema.additionalProperties = false;
+        }
+        return schema;
       } else if (methodName === "union" && node.arguments.length > 0) {
         return this.processZodUnion(node);
       } else if (methodName === "intersection" && node.arguments.length > 0) {

--- a/tests/unit/schema/zod/features/object-modes.test.ts
+++ b/tests/unit/schema/zod/features/object-modes.test.ts
@@ -43,6 +43,30 @@ describe("Zod features › object modes", () => {
     });
   });
 
+  it("z.strictObject() emits additionalProperties: false", () => {
+    const schema = convert(
+      `z.strictObject({ id: z.string(), name: z.string().optional() })`,
+      roots,
+    );
+    expect(schema).toMatchObject({
+      type: "object",
+      properties: {
+        id: { type: "string" },
+        name: { type: "string" },
+      },
+      required: ["id"],
+      additionalProperties: false,
+    });
+  });
+
+  it("z.strictObject() without arguments emits plain object", () => {
+    const schema = convert(`z.strictObject({})`, roots);
+    expect(schema).toMatchObject({
+      type: "object",
+      additionalProperties: false,
+    });
+  });
+
   it("strip() is a no-op (explicit default)", () => {
     const schema = convert(`${base}.strip()`, roots);
     expect(schema).toMatchObject({ type: "object" });


### PR DESCRIPTION
## Description

`z.strictObject(...)` was not recognized by the Zod schema backend and fell through to the `default` case of `processZodPrimitiveNode`, returning `{ type: "string" }` instead of a proper object schema.

**Before:** `z.strictObject({ id: z.string() })` → `{ type: "string" }` ❌
**After:** `z.strictObject({ id: z.string() })` → `{ type: "object", properties: { id: { type: "string" } }, required: ["id"], additionalProperties: false }` ✅

Three locations are fixed: `node-helpers.ts` (AST primitive path), `zod-converter.ts` (top-level node dispatch), and `runtime-exporter.ts` (runtime Zod evaluation path). `additionalProperties: false` is set in all three, matching Zod's strict semantics.

## Type of Change

- [ ] ✨ **feat:** New feature
- [x] 🐛 **fix:** Bug fix
- [ ] 📝 **docs:** Documentation update
- [ ] ♻️ **refactor:** Code refactoring
- [ ] ⚡ **perf:** Performance improvement
- [ ] 💥 **Breaking change** (add `!` after type, e.g., `feat!:`)

## Checklist

- [x] `pnpm check` passes
- [x] Tested locally (`pnpm test:unit` — 293 tests pass; `pnpm build` — 33 tasks successful)
- [ ] Documentation updated (if needed)