### PR TITLE
fix(zod): prevent infinite recursion on re-export files using z.infer<typeof schema>

### DIFF
--- a/packages/openapi-core/src/schema/zod/zod-converter.ts
+++ b/packages/openapi-core/src/schema/zod/zod-converter.ts
@@ -58,7 +58,9 @@ export class ZodSchemaConverter {
   apiDir: string | undefined;
   zodSchemas: Record<string, OpenApiSchema> = {};
   processingSchemas: Set<string> = new Set();
-  processedModules: Set<string> = new Set();
+  /** Memoization guard for processFileForZodSchema. Keys: `${filePath}|${schemaName}`.
+   * Prevents infinite recursion when re-export files reference schemas via z.infer<typeof X>. */
+  processedFileSchemaPairs: Set<string> = new Set();
   typeToSchemaMapping: Record<string, string> = {};
   drizzleZodImports: Set<string> = new Set();
   factoryCache: Map<string, t.Node> = new Map(); // Cache for analyzed factory functions
@@ -347,6 +349,12 @@ export class ZodSchemaConverter {
    * Process a file to find Zod schema definitions
    */
   processFileForZodSchema(filePath: string, schemaName: string): void {
+    const visitKey = `${filePath}|${schemaName}|${this.currentContentType}`;
+    if (this.processedFileSchemaPairs.has(visitKey)) {
+      return;
+    }
+    this.processedFileSchemaPairs.add(visitKey);
+
     try {
       const content = this.fileAccess.readFileSync(filePath, "utf-8");
 
@@ -829,8 +837,9 @@ export class ZodSchemaConverter {
                 const param = path.node.typeAnnotation.typeParameters.params[0];
                 if (t.isTSTypeQuery(param) && t.isIdentifier(param.exprName)) {
                   const referencedSchemaName = param.exprName.name;
-                  // Find the referenced schema
-                  this.processFileForZodSchema(filePath, referencedSchemaName);
+                  if (!this.getStoredSchema(referencedSchemaName)) {
+                    this.processFileForZodSchema(filePath, referencedSchemaName);
+                  }
                 }
               }
             }

--- a/tests/fixtures/zod-reexport-recursion/apiError.ts
+++ b/tests/fixtures/zod-reexport-recursion/apiError.ts
@@ -1,0 +1,5 @@
+import type { z } from "zod";
+import type { apiErrorIssueSchema, apiErrorSchema } from "./schemas/apiErrorSchema";
+
+export type ApiError = z.infer<typeof apiErrorSchema>;
+export type ApiErrorIssue = z.infer<typeof apiErrorIssueSchema>;

--- a/tests/fixtures/zod-reexport-recursion/schemas/apiErrorSchema.ts
+++ b/tests/fixtures/zod-reexport-recursion/schemas/apiErrorSchema.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+export const apiErrorIssueSchema = z.object({
+  path: z.array(z.string()),
+  message: z.string(),
+  code: z.string().optional(),
+});
+
+export const apiErrorSchema = z.object({
+  message: z.string(),
+  code: z.string().optional(),
+  issues: z.array(apiErrorIssueSchema).optional(),
+});

--- a/tests/integration/regressions/typescript-and-zod-regressions.test.ts
+++ b/tests/integration/regressions/typescript-and-zod-regressions.test.ts
@@ -78,5 +78,22 @@ describe("TypeScript and Zod regression scenarios", () => {
       expect(schema?.oneOf).toHaveLength(3);
       expect(schema?.discriminator?.propertyName).toBe("type");
     });
+
+    it("does not infinite-recurse on re-export files using z.infer<typeof schema>", () => {
+      // Regression for https://github.com/tazo90/next-openapi-gen/issues/127:
+      // scanning a schemaDir that contains a barrel file with only
+      // `import type { X }` + `export type Y = z.infer<typeof X>` caused unbounded
+      // recursion in processFileForZodSchema → RangeError / heap OOM.
+      const converter = new ZodSchemaConverter(
+        path.join(process.cwd(), "tests", "fixtures", "zod-reexport-recursion"),
+      );
+
+      const schema = converter.convertZodSchemaToOpenApi("apiErrorSchema");
+
+      expect(schema).toBeDefined();
+      expect(schema?.type).toBe("object");
+      expect(schema?.properties?.message).toEqual({ type: "string" });
+      expect(schema?.properties?.issues).toBeDefined();
+    });
   });
 });


### PR DESCRIPTION
## Description

Fixes #127.

When `schemaDir` includes a directory containing TypeScript barrel/re-export files that use `z.infer<typeof SomeSchema>` (with only `import type` imports and no local Zod schema definitions), `ZodSchemaConverter.processFileForZodSchema` entered unbounded recursion, eventually crashing with `RangeError: Maximum call stack size exceeded` → JavaScript heap out of memory.

**Root cause:** The AST visitor in `processFileForZodSchema` finds imported schema names via `z.infer<typeof X>` type aliases and recursively calls `processFileForZodSchema(filePath, X)` on the same file. Since the imported schema is never found locally, the call keeps re-entering indefinitely. There was no `(filePath, schemaName)` visited guard to break the cycle.

**Fix:** Added a `(filePath × schemaName × contentType)` memoization guard at the entry of `processFileForZodSchema` using the existing (dead) `processedModules` field, renamed to `processedFileSchemaPairs`. Including `contentType` in the key preserves the intentional behavior where `response` and `body` content types produce separate schema variants for the same schema.

Additionally, the `TSTypeAliasDeclaration` short-path (`infer<typeof X>`) at line ~841 was missing the `getStoredSchema` pre-check present on all other three recursive call sites — that is now consistent.

A regression fixture and integration test are included that reproduce the crash without the fix.

## Type of Change

- [x] 🐛 **fix:** Bug fix

## Checklist

- [x] `pnpm check` passes
- [x] Tested locally (`pnpm test` and `pnpm build`)
- [x] Documentation updated (if needed)