### PR TITLE
fix(zod): resolve cross-file schemas via reverse naming convention (#131)

### DIFF
--- a/packages/openapi-core/src/schema/zod/zod-converter.ts
+++ b/packages/openapi-core/src/schema/zod/zod-converter.ts
@@ -118,7 +118,19 @@ export class ZodSchemaConverter {
 
     // Check mapped types
     const requestedSchemaName = schemaName;
-    const mappedSchemaName = this.typeToSchemaMapping[schemaName];
+    let mappedSchemaName = this.typeToSchemaMapping[schemaName];
+
+    // Reverse-convention fallback (issue #131): when `Slider = z.infer<typeof sliderSchema>`
+    // lives outside any scanned file, no mapping exists. Derive the candidate schema name
+    // from the type name and verify it is present in schemaDirs before committing.
+    if (!mappedSchemaName) {
+      const candidate = this.deriveSchemaNameByConvention(schemaName);
+      if (candidate && this.locateSchemaByConvention(candidate)) {
+        this.typeToSchemaMapping[schemaName] = candidate;
+        mappedSchemaName = candidate;
+      }
+    }
+
     if (mappedSchemaName) {
       logger.debug(`Type '${schemaName}' is mapped to schema '${mappedSchemaName}'`);
       schemaName = mappedSchemaName;
@@ -2409,6 +2421,45 @@ export class ZodSchemaConverter {
         `Schema component name '${overrideId ?? finalName}' conflicts with an existing schema, ignoring .meta({ id }) on '${schemaName}'`,
       );
     }
+  }
+
+  /**
+   * Derives the conventional Zod schema name from a TypeScript type name.
+   * e.g. "Slider" → "sliderSchema", "SliderItem" → "sliderItemSchema".
+   * Returns null when the input is already a schema name or is not PascalCase.
+   */
+  private deriveSchemaNameByConvention(typeName: string): string | null {
+    if (!typeName || !/^[A-Z]/.test(typeName) || typeName.endsWith("Schema")) {
+      return null;
+    }
+    return typeName[0]!.toLowerCase() + typeName.slice(1) + "Schema";
+  }
+
+  /**
+   * Checks whether a Zod schema with the given name is present in schemaDirs
+   * WITHOUT populating the processed-schema cache. A file-content substring check
+   * (the same heuristic used by processFileForZodSchema) is sufficient here: we
+   * only want to know whether the candidate *might* live in schemaDirs so that the
+   * convention mapping can be registered; the actual processing happens later in
+   * the normal convertZodSchemaToOpenApi lookup flow.
+   */
+  private locateSchemaByConvention(candidate: string): boolean {
+    if (this.schemaNameToFiles.has(candidate)) {
+      return true;
+    }
+    for (const dir of this.schemaDirs) {
+      for (const filePath of this.getSchemaFiles(dir)) {
+        try {
+          const content = this.fileAccess.readFileSync(filePath, "utf-8");
+          if (content.includes(candidate)) {
+            return true;
+          }
+        } catch {
+          // ignore unreadable files
+        }
+      }
+    }
+    return false;
   }
 
   /**

--- a/tests/fixtures/zod-cross-file-convention/schemas/sliderSchema.ts
+++ b/tests/fixtures/zod-cross-file-convention/schemas/sliderSchema.ts
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const sliderSchema = z.object({
+  pimId: z.number().int().positive().describe("Slider PIM ID"),
+  language: z.string(),
+});

--- a/tests/fixtures/zod-cross-file-convention/types/slider.ts
+++ b/tests/fixtures/zod-cross-file-convention/types/slider.ts
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+import { sliderSchema } from "../schemas/sliderSchema.js";
+
+export type Slider = z.infer<typeof sliderSchema>;

--- a/tests/integration/regressions/typescript-and-zod-regressions.test.ts
+++ b/tests/integration/regressions/typescript-and-zod-regressions.test.ts
@@ -175,5 +175,20 @@ describe("TypeScript and Zod regression scenarios", () => {
       expect(schema?.properties?.message).toEqual({ type: "string" });
       expect(schema?.properties?.issues).toBeDefined();
     });
+
+    it("links cross-file Zod schema via reverse naming convention (issue #131)", () => {
+      const converter = new ZodSchemaConverter(
+        path.join(process.cwd(), "tests", "fixtures", "zod-cross-file-convention", "schemas"),
+      );
+      const schema = converter.convertZodSchemaToOpenApi("Slider");
+
+      expect(schema?.type).toBe("object");
+      expect(schema?.properties?.pimId).toMatchObject({
+        type: "integer",
+        description: "Slider PIM ID",
+      });
+      expect(schema?.properties?.language).toMatchObject({ type: "string" });
+      expect(converter.getSchemaReferenceName("Slider")).toBe("Slider");
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Adds a reverse-naming-convention fallback in `convertZodSchemaToOpenApi` so that a TypeScript type name (`Slider`) is linked to its Zod schema (`sliderSchema`) even when the `z.infer` alias lives **outside** any scanned route or `schemaDir` file
- Derives the candidate schema name via `lowerFirst(typeName) + "Schema"`, verifies it appears in schemaDir files with a cheap content-includes check (no cache pollution), then registers the mapping so the existing alias-copy logic in the `finally` block propagates the resolved schema under the original TypeScript name
- Adds a regression fixture (`tests/fixtures/zod-cross-file-convention/`) and a new integration test that asserts full property resolution (`description`, correct types) for the cross-file case

Closes #131
Requires #128 (infinite-recursion fix) as prerequisite

## Test plan

- [x] `pnpm check` — typecheck + lint pass
- [x] `pnpm run test:unit` — 655 tests pass
- [x] `pnpm run test:integration` — 57 tests pass (including new regression)
- [x] `pnpm build` — all 33 tasks succeed
- [x] New test: `links cross-file Zod schema via reverse naming convention (issue #131)` asserts `schema.properties.pimId.description === "Slider PIM ID"` and `getSchemaReferenceName("Slider") === "Slider"`