### PR TITLE
feat: support configurable @auth preset mappings via authPresets config

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,33 +288,34 @@ Version guidance:
 | `ignoreRoutes`                        | Exclude routes with wildcard support                             |
 | `defaultResponseSet` / `responseSets` | Reusable error-response groups                                   |
 | `errorConfig`                         | Shared error schema templates                                    |
+| `authPresets`                         | Override or extend the `@auth` keyword → scheme-name mapping     |
 
 For a fuller setup guide, Pages Router notes, response sets, and route exclusion
 patterns, see [docs/getting-started.md](./docs/getting-started.md).
 
 ## JSDoc tags you will use most
 
-| Tag                        | Purpose                                                          |
-| -------------------------- | ---------------------------------------------------------------- |
-| `@pathParams`              | Path parameter schema or type                                    |
-| `@params` / `@queryParams` | Query parameter schema or type                                   |
-| `@header` / `@cookie`      | Header / cookie parameter schema or type                         |
-| `@body`                    | Request body schema or type                                      |
-| `@response`                | Response schema, code, and optional description                  |
-| `@responseDescription`     | Response description without redefining the schema               |
-| `@responseHeader`          | Add a response header to a given status code                     |
-| `@link`                    | Add an OpenAPI link to a response                                |
-| `@auth` / `@security`      | Security requirement(s); `@security` accepts explicit scopes     |
-| `@servers`                 | Operation-level servers                                          |
-| `@externalDocs`            | Operation-level external documentation                           |
-| `@callback`                | OpenAPI operation callback                                       |
-| `@webhook`                 | Mark the handler as a webhook (`3.1`+ `webhooks` section)        |
-| `@contentType`             | Request content type such as `multipart/form-data`               |
-| `@examples`                | Request, response, and querystring examples                      |
-| `@openapi`                 | Explicit inclusion marker when `includeOpenApiRoutes` is enabled |
-| `@openapi-override`        | Deep-merge extra OpenAPI fields onto the operation               |
-| `@ignore`                  | Exclude a route from generation                                  |
-| `@method`                  | Required HTTP method tag for Pages Router handlers               |
+| Tag                        | Purpose                                                                                                 |
+| -------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `@pathParams`              | Path parameter schema or type                                                                           |
+| `@params` / `@queryParams` | Query parameter schema or type                                                                          |
+| `@header` / `@cookie`      | Header / cookie parameter schema or type                                                                |
+| `@body`                    | Request body schema or type                                                                             |
+| `@response`                | Response schema, code, and optional description                                                         |
+| `@responseDescription`     | Response description without redefining the schema                                                      |
+| `@responseHeader`          | Add a response header to a given status code                                                            |
+| `@link`                    | Add an OpenAPI link to a response                                                                       |
+| `@auth` / `@security`      | Security requirement(s); built-in presets: `bearer`, `basic`, `apikey` — configurable via `authPresets` |
+| `@servers`                 | Operation-level servers                                                                                 |
+| `@externalDocs`            | Operation-level external documentation                                                                  |
+| `@callback`                | OpenAPI operation callback                                                                              |
+| `@webhook`                 | Mark the handler as a webhook (`3.1`+ `webhooks` section)                                               |
+| `@contentType`             | Request content type such as `multipart/form-data`                                                      |
+| `@examples`                | Request, response, and querystring examples                                                             |
+| `@openapi`                 | Explicit inclusion marker when `includeOpenApiRoutes` is enabled                                        |
+| `@openapi-override`        | Deep-merge extra OpenAPI fields onto the operation                                                      |
+| `@ignore`                  | Exclude a route from generation                                                                         |
+| `@method`                  | Required HTTP method tag for Pages Router handlers                                                      |
 
 For the complete tag guide and usage recipes, see
 [docs/jsdoc-reference.md](./docs/jsdoc-reference.md).

--- a/docs/jsdoc-reference.md
+++ b/docs/jsdoc-reference.md
@@ -186,6 +186,39 @@ Comma-separated values produce alternative security requirements. For example,
 Advanced `securitySchemes` objects should still be modeled in templates or
 reusable OpenAPI fragments.
 
+**Built-in presets** map the following lowercase keywords to scheme names:
+
+| Keyword  | Default scheme name |
+| -------- | ------------------- |
+| `bearer` | `BearerAuth`        |
+| `basic`  | `BasicAuth`         |
+| `apikey` | `ApiKeyAuth`        |
+
+You can override these or add new presets via the `authPresets` config option:
+
+```ts
+// openapi-gen.config.ts
+export default defineConfig({
+  authPresets: {
+    bearer: "JwtAuth", // override default BearerAuth
+    oauth2: "OAuth2Auth", // add a new preset
+  },
+  components: {
+    securitySchemes: {
+      JwtAuth: { type: "http", scheme: "bearer", bearerFormat: "JWT" },
+      OAuth2Auth: {
+        type: "oauth2",
+        flows: {
+          /* ... */
+        },
+      },
+    },
+  },
+});
+```
+
+Unknown values (e.g. `@auth MyCustomScheme`) are passed through unchanged regardless of preset configuration.
+
 ### File uploads
 
 ```ts

--- a/packages/openapi-core/src/config/normalize.ts
+++ b/packages/openapi-core/src/config/normalize.ts
@@ -24,6 +24,7 @@ import {
   DEFAULT_SCHEMA_DIR,
   DEFAULT_UI,
 } from "./defaults.js";
+import { DEFAULT_AUTH_PRESET_REPLACEMENTS } from "../shared/utils.js";
 
 function normalizeRouterType(routerType?: RouterType): RouterType {
   return routerType ?? DEFAULT_ROUTER_TYPE;
@@ -144,6 +145,7 @@ export function normalizeOpenApiConfig(
       adapterPath: template.next?.adapterPath,
     },
     diagnostics: template.diagnostics ?? { enabled: DEFAULT_DIAGNOSTICS_ENABLED },
+    authPresets: { ...DEFAULT_AUTH_PRESET_REPLACEMENTS, ...template.authPresets },
     debug: template.debug ?? DEFAULT_DEBUG,
   };
 }

--- a/packages/openapi-core/src/routes/operation-processor.ts
+++ b/packages/openapi-core/src/routes/operation-processor.ts
@@ -2,16 +2,33 @@ import type { GenerationPerformanceProfile } from "../core/performance.js";
 import { measurePerformance } from "../core/performance.js";
 import type { SchemaProcessor } from "../schema/typescript/schema-processor.js";
 import { createMultipartEncoding } from "../schema/typescript/helpers.js";
-import { capitalize, getOperationId } from "../shared/utils.js";
+import {
+  capitalize,
+  DEFAULT_AUTH_PRESET_REPLACEMENTS,
+  getOperationId,
+  performAuthPresetReplacements,
+} from "../shared/utils.js";
 import type { DataTypes, ParamSchema, RouteDefinition } from "../shared/types.js";
 import { ResponseProcessor } from "./response-processor.js";
 
 export class OperationProcessor {
+  private readonly authPresets: Record<string, string>;
+  private readonly performanceProfile: GenerationPerformanceProfile | undefined;
+
   constructor(
     private readonly schemaProcessor: SchemaProcessor,
     private readonly responseProcessor: ResponseProcessor,
-    private readonly performanceProfile?: GenerationPerformanceProfile,
-  ) {}
+    options: {
+      authPresets?: Record<string, string> | undefined;
+      performanceProfile?: GenerationPerformanceProfile | undefined;
+    } = {},
+  ) {
+    this.authPresets = {
+      ...DEFAULT_AUTH_PRESET_REPLACEMENTS,
+      ...options.authPresets,
+    };
+    this.performanceProfile = options.performanceProfile;
+  }
 
   public processOperation(
     varName: string,
@@ -72,9 +89,14 @@ export class OperationProcessor {
     }
 
     if (explicitSecurity && explicitSecurity.length > 0) {
-      definition.security = explicitSecurity;
+      definition.security = explicitSecurity.map((req) =>
+        Object.fromEntries(
+          Object.entries(req).map(([scheme, scopes]) => [this.applyPreset(scheme), scopes]),
+        ),
+      );
     } else if (auth) {
-      const authItems = auth.split(",").map((item) => item.trim());
+      const mapped = performAuthPresetReplacements(auth, this.authPresets);
+      const authItems = mapped.split(",").map((item) => item.trim());
       definition.security = authItems.map((authItem) => ({
         [authItem]: [],
       }));
@@ -384,6 +406,10 @@ export class OperationProcessor {
       }
       response.links[link.name] = linkObject;
     }
+  }
+
+  private applyPreset(scheme: string): string {
+    return this.authPresets[scheme.toLowerCase()] ?? scheme;
   }
 
   private createQuerystringParameter(dataTypes: DataTypes): ParamSchema | undefined {

--- a/packages/openapi-core/src/routes/route-processor.ts
+++ b/packages/openapi-core/src/routes/route-processor.ts
@@ -75,11 +75,10 @@ export class RouteProcessor {
       return new RegExp(`^${regexPattern}$`);
     });
     this.responseProcessor = new ResponseProcessor(this.config, this.schemaProcessor);
-    this.operationProcessor = new OperationProcessor(
-      this.schemaProcessor,
-      this.responseProcessor,
-      this.performanceProfile,
-    );
+    this.operationProcessor = new OperationProcessor(this.schemaProcessor, this.responseProcessor, {
+      authPresets: this.config.authPresets,
+      performanceProfile: this.performanceProfile,
+    });
   }
 
   private processResponsesFromConfig(

--- a/packages/openapi-core/src/shared/types.ts
+++ b/packages/openapi-core/src/shared/types.ts
@@ -74,12 +74,16 @@ export type OpenApiConfig = {
     adapterPath?: string | undefined;
   };
   diagnostics?: DiagnosticsConfig | undefined;
+  /** Override or extend the default JSDoc @auth → security-scheme-name mapping.
+   *  Defaults: { bearer: "BearerAuth", basic: "BasicAuth", apikey: "ApiKeyAuth" }.
+   *  User keys win on conflict; lookup is case-insensitive. */
+  authPresets?: Record<string, string> | undefined;
   debug: boolean;
 };
 
 export type ResolvedOpenApiConfig = Omit<
   OpenApiConfig,
-  "routerType" | "schemaType" | "framework" | "next" | "diagnostics"
+  "routerType" | "schemaType" | "framework" | "next" | "diagnostics" | "authPresets"
 > & {
   framework: FrameworkConfig;
   next: {
@@ -90,6 +94,7 @@ export type ResolvedOpenApiConfig = Omit<
   schemaType: SchemaType | SchemaType[];
   schemaBackends: SchemaType[];
   openapiVersion: OpenApiVersion;
+  authPresets: Record<string, string>;
 };
 
 export type OpenApiInfo = {
@@ -179,6 +184,7 @@ export type OpenApiTemplate = OpenApiDocument & {
     adapterPath?: string | undefined;
   };
   diagnostics?: DiagnosticsConfig | undefined;
+  authPresets?: Record<string, string> | undefined;
   debug?: boolean | undefined;
 };
 

--- a/packages/openapi-core/src/shared/utils.ts
+++ b/packages/openapi-core/src/shared/utils.ts
@@ -1011,6 +1011,7 @@ const INTERNAL_OPENAPI_CONFIG_KEYS = [
   "next",
   "diagnostics",
   "debug",
+  "authPresets",
 ] as const;
 
 export const DEFAULT_AUTH_PRESET_REPLACEMENTS: Record<string, string> = {

--- a/packages/openapi-core/src/shared/utils.ts
+++ b/packages/openapi-core/src/shared/utils.ts
@@ -105,7 +105,7 @@ export function parseJSDocBlock(commentValue: string, filePath?: string): DataTy
 
   const authValue = extractLineValue(normalizedComment, "@auth");
   if (authValue) {
-    result.auth = performAuthPresetReplacements(authValue);
+    result.auth = authValue;
   }
 
   const querystring = parseQuerystringTag(normalizedComment);
@@ -1013,15 +1013,18 @@ const INTERNAL_OPENAPI_CONFIG_KEYS = [
   "debug",
 ] as const;
 
-const AUTH_PRESET_REPLACEMENTS: Record<string, string> = {
+export const DEFAULT_AUTH_PRESET_REPLACEMENTS: Record<string, string> = {
   bearer: "BearerAuth",
   basic: "BasicAuth",
   apikey: "ApiKeyAuth",
 };
 
-export function performAuthPresetReplacements(authValue: string): string {
+export function performAuthPresetReplacements(
+  authValue: string,
+  presets: Record<string, string> = DEFAULT_AUTH_PRESET_REPLACEMENTS,
+): string {
   const authParts = authValue.split(",").map((part) => part.trim());
-  const mappedParts = authParts.map((part) => AUTH_PRESET_REPLACEMENTS[part.toLowerCase()] || part);
+  const mappedParts = authParts.map((part) => presets[part.toLowerCase()] || part);
 
   return mappedParts.join(",");
 }

--- a/tests/integration/generator/openapi-generator-flow.test.ts
+++ b/tests/integration/generator/openapi-generator-flow.test.ts
@@ -363,4 +363,17 @@ describe.sequential("OpenApiGenerator integration flow", () => {
       project.cleanup();
     }
   });
+
+  it("applies authPresets config override, replacing bearer with a custom scheme name", () => {
+    const { project, spec } = generateFixtureSpec({
+      fixturePath: appRouterCoreFixture,
+      templateOverrides: { authPresets: { bearer: "JwtAuth" } },
+    });
+
+    try {
+      expect(spec.paths?.["/users/{id}"]?.get?.security).toEqual([{ JwtAuth: [] }]);
+    } finally {
+      project.cleanup();
+    }
+  });
 });

--- a/tests/unit/regressions/shared-utils.test.ts
+++ b/tests/unit/regressions/shared-utils.test.ts
@@ -55,7 +55,7 @@ describe("shared JSDoc utilities regressions", () => {
     });
 
     expect(dataTypes?.operationId).toBe("createNewUser");
-    expect(dataTypes?.auth).toBe("BearerAuth,CustomType");
+    expect(dataTypes?.auth).toBe("bearer,CustomType");
     expect(dataTypes?.successCode).toBe("201");
     expect(dataTypes?.responseType).toBe("UserResponse");
   });

--- a/tests/unit/routes/operation-processor.test.ts
+++ b/tests/unit/routes/operation-processor.test.ts
@@ -69,7 +69,7 @@ describe("OperationProcessor", () => {
       "POST",
       "/users/{id}",
       {
-        auth: "BearerAuth,ApiKeyAuth",
+        auth: "bearer,apikey",
         deprecated: true,
         summary: "Create user",
         description: "Creates a user",
@@ -279,7 +279,7 @@ describe("OperationProcessor", () => {
         tag: "Users",
         summary: "Create user",
         description: "Creates a user",
-        auth: "BearerAuth,ApiKeyAuth",
+        auth: "bearer,apikey",
         deprecated: true,
         paramsType: "UserQuery",
         bodyType: "CreateUserBody",
@@ -621,5 +621,51 @@ describe("OperationProcessor", () => {
 
     expect((result.definition as Record<string, unknown>)["x-internal"]).toBe(true);
     expect((result.definition as Record<string, unknown>)["x-rate-limit"]).toBe(100);
+  });
+
+  it("applies custom authPresets, with user keys winning over defaults", () => {
+    const schemaProcessor = {
+      getSchemaContent: vi.fn<MockFn>(() => ({
+        params: undefined,
+        pathParams: undefined,
+        body: undefined,
+        responses: undefined,
+      })),
+      createRequestParamsSchema: vi.fn<MockFn>(() => []),
+      createDefaultPathParamsSchema: vi.fn<MockFn>(),
+      detectContentType: vi.fn<MockFn>(),
+      createResponseSchema: vi.fn<MockFn>(() => ({})),
+      ensureSchemaResolved: vi.fn<MockFn>(),
+      getSchemaReferenceName: vi.fn<MockFn>((name: string) => name),
+    };
+    const responseProcessor = {
+      supportsRequestBody: vi.fn<MockFn>(() => false),
+      processResponses: vi.fn<MockFn>(() => ({})),
+    };
+
+    const processor = new OperationProcessor(schemaProcessor as never, responseProcessor as never, {
+      authPresets: { bearer: "JwtAuth", oauth2: "OAuth2Flow" },
+    });
+
+    const withOverride = processor.processOperation("GET", "/a", { tag: "A", auth: "bearer" });
+    expect(withOverride.definition.security).toEqual([{ JwtAuth: [] }]);
+
+    const withNewPreset = processor.processOperation("GET", "/b", {
+      tag: "B",
+      auth: "bearer,oauth2",
+    });
+    expect(withNewPreset.definition.security).toEqual([{ JwtAuth: [] }, { OAuth2Flow: [] }]);
+
+    const passThrough = processor.processOperation("GET", "/c", {
+      tag: "C",
+      auth: "MyCustomScheme",
+    });
+    expect(passThrough.definition.security).toEqual([{ MyCustomScheme: [] }]);
+
+    const withSecurity = processor.processOperation("GET", "/d", {
+      tag: "D",
+      security: [{ bearer: ["read"] }],
+    });
+    expect(withSecurity.definition.security).toEqual([{ JwtAuth: ["read"] }]);
   });
 });

--- a/tests/unit/routes/pages-router-strategy.test.ts
+++ b/tests/unit/routes/pages-router-strategy.test.ts
@@ -110,7 +110,7 @@ describe("PagesRouterStrategy", () => {
 
       expect(result.pathParamsType).toBe("UserIdSchema");
       expect(result.paramsType).toBe("UserQuerySchema");
-      expect(result.auth).toBe("BearerAuth,CustomType");
+      expect(result.auth).toBe("bearer,CustomType");
       expect(result.operationId).toBe("getUserById");
       expect(result.addResponses).toBe("401:ErrorResponse,500:ErrorResponse");
     });
@@ -146,7 +146,7 @@ describe("PagesRouterStrategy", () => {
       expect(result.bodyDescription).toBe("Avatar form data");
       expect(result.contentType).toBe("multipart/form-data");
       expect(result.responseSet).toBe("errors");
-      expect(result.auth).toBe("ApiKeyAuth");
+      expect(result.auth).toBe("apikey");
     });
 
     it("handles status-only responses and basic auth", () => {
@@ -163,7 +163,7 @@ describe("PagesRouterStrategy", () => {
       expect(result.successCode).toBe("204");
       expect(result.responseType).toBe("");
       expect(result.responseDescription).toBe("Deleted");
-      expect(result.auth).toBe("BasicAuth");
+      expect(result.auth).toBe("basic");
     });
 
     it("supports inline response descriptions from README-style syntax", () => {
@@ -191,7 +191,7 @@ describe("PagesRouterStrategy", () => {
 
       expect(result.summary).toBe("");
       expect(result.tag).toBe("Reports");
-      expect(result.auth).toBe("BearerAuth,ApiKeyAuth,CustomScheme");
+      expect(result.auth).toBe("bearer,ApiKeyAuth,CustomScheme");
       expect(result.responseType).toBe("");
       expect(result.successCode).toBe("");
     });

--- a/tests/unit/shared/utils.test.ts
+++ b/tests/unit/shared/utils.test.ts
@@ -72,7 +72,7 @@ describe("shared utils", () => {
       tagSummary: "",
       tagKind: "",
       tagParent: "",
-      auth: "BasicAuth",
+      auth: "basic",
       summary: "Create a user",
       description: "Creates a user record",
       paramsType: "UserQuery",
@@ -149,7 +149,7 @@ describe("shared utils", () => {
       export async function GET() {}
     `);
 
-    expect(data?.auth).toBe("ApiKeyAuth");
+    expect(data?.auth).toBe("apikey");
     expect(data?.responseType).toBe("");
     expect(data?.successCode).toBe("");
   });
@@ -196,7 +196,7 @@ describe("shared utils", () => {
       export async function POST() {}
     `);
 
-    expect(bearerData?.auth).toBe("BearerAuth");
+    expect(bearerData?.auth).toBe("bearer");
     expect(emptyAuthData?.auth).toBe("");
   });
 
@@ -368,6 +368,15 @@ describe("shared utils", () => {
   it("normalizes auth preset casing while keeping unknown entries", () => {
     expect(performAuthPresetReplacements("BEARER, apiKey, custom-scheme")).toBe(
       "BearerAuth,ApiKeyAuth,custom-scheme",
+    );
+  });
+
+  it("applies custom presets when provided, with user keys winning over defaults", () => {
+    const custom = { bearer: "JwtAuth", oauth2: "OAuth2Auth" };
+    expect(performAuthPresetReplacements("bearer", custom)).toBe("JwtAuth");
+    expect(performAuthPresetReplacements("bearer,oauth2", custom)).toBe("JwtAuth,OAuth2Auth");
+    expect(performAuthPresetReplacements("bearer,CustomScheme", custom)).toBe(
+      "JwtAuth,CustomScheme",
     );
   });
 


### PR DESCRIPTION
## Description

The generator has a hardcoded mapping table that translates `@auth` keywords to security scheme names:

- `bearer` → `BearerAuth`
- `basic` → `BasicAuth`
- `apikey` → `ApiKeyAuth`

There is currently no way to override these mappings through configuration. Users who name their schemes differently (e.g. `JwtAuth` instead of `BearerAuth`) must either write the full scheme name in every route handler comment or switch to the more verbose `@security` tag.

This PR introduces an optional `authPresets` config field that is deep-merged over the defaults (user keys win). Existing behaviour is fully preserved — no changes are required in existing configs or route comments.

### Example

```ts
// openapi-gen.config.ts
export default defineConfig({
  authPresets: {
    bearer: "JwtAuth",    // overrides default BearerAuth
    oauth2: "OAuth2Auth", // adds a new preset
  },
  components: {
    securitySchemes: {
      JwtAuth: { type: "http", scheme: "bearer", bearerFormat: "JWT" },
      OAuth2Auth: { type: "oauth2", flows: { /* ... */ } },
    },
  },
});
```

With the config above, `@auth bearer` produces `security: [{ JwtAuth: [] }]` instead of `security: [{ BearerAuth: [] }]`. The `basic` and `apikey` defaults remain active unless explicitly overridden.

### Implementation notes

- The preset mapping is moved from the low-level `extractJSDocComments` utility (which has no config access) to `OperationProcessor`, which is the single consumer of `dataTypes.auth`.
- `DEFAULT_AUTH_PRESET_REPLACEMENTS` is now exported so callers and tests can reference the canonical defaults.
- `performAuthPresetReplacements` gains an optional `presets` parameter (default = the exported constant), preserving backward compatibility for any direct callers.
- The mapping also applies to `@security` scheme keys — `@security bearer:read` will resolve `bearer` through the same table. Existing configs that already write full names (e.g. `BearerAuth`) are unaffected because full names are not in the table.
- `normalizeOpenApiConfig` merges user presets over defaults so every downstream consumer receives a complete, resolved `Record<string, string>`.

## Type of Change

- [x] ✨ **feat:** New feature

## Checklist

- [x] `pnpm check` passes
- [x] Tested locally (`pnpm test` and `pnpm build` pass)
- [x] Documentation updated (`docs/jsdoc-reference.md`, `README.md`)