### PR TITLE
feat: exclude internal schemas from components via @internal tag and excludeSchemas config

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,19 +276,20 @@ Version guidance:
 
 ### Important options
 
-| Option                                | Purpose                                                          |
-| ------------------------------------- | ---------------------------------------------------------------- |
-| `openapi`                             | Target `3.0.0`, `3.1.0`, or `3.2.0` output                       |
-| `apiDir`                              | Route directory to scan                                          |
-| `routerType`                          | `"app"` or `"pages"`                                             |
-| `schemaDir`                           | Directory or directories to search for schemas/types             |
-| `schemaType`                          | `"zod"`, `"typescript"`, or both                                 |
-| `schemaFiles`                         | YAML/JSON OpenAPI fragments to merge into the generated document |
-| `includeOpenApiRoutes`                | Only include handlers tagged with `@openapi`                     |
-| `ignoreRoutes`                        | Exclude routes with wildcard support                             |
-| `defaultResponseSet` / `responseSets` | Reusable error-response groups                                   |
-| `errorConfig`                         | Shared error schema templates                                    |
-| `authPresets`                         | Override or extend the `@auth` keyword → scheme-name mapping     |
+| Option                                | Purpose                                                                                 |
+| ------------------------------------- | --------------------------------------------------------------------------------------- |
+| `openapi`                             | Target `3.0.0`, `3.1.0`, or `3.2.0` output                                              |
+| `apiDir`                              | Route directory to scan                                                                 |
+| `routerType`                          | `"app"` or `"pages"`                                                                    |
+| `schemaDir`                           | Directory or directories to search for schemas/types                                    |
+| `schemaType`                          | `"zod"`, `"typescript"`, or both                                                        |
+| `schemaFiles`                         | YAML/JSON OpenAPI fragments to merge into the generated document                        |
+| `includeOpenApiRoutes`                | Only include handlers tagged with `@openapi`                                            |
+| `ignoreRoutes`                        | Exclude routes with wildcard support                                                    |
+| `excludeSchemas`                      | Exclude internal schemas from `components/schemas` by name or glob (e.g. `["*Params"]`) |
+| `defaultResponseSet` / `responseSets` | Reusable error-response groups                                                          |
+| `errorConfig`                         | Shared error schema templates                                                           |
+| `authPresets`                         | Override or extend the `@auth` keyword → scheme-name mapping                            |
 
 For a fuller setup guide, Pages Router notes, response sets, and route exclusion
 patterns, see [docs/getting-started.md](./docs/getting-started.md).
@@ -315,6 +316,7 @@ patterns, see [docs/getting-started.md](./docs/getting-started.md).
 | `@openapi`                 | Explicit inclusion marker when `includeOpenApiRoutes` is enabled                                        |
 | `@openapi-override`        | Deep-merge extra OpenAPI fields onto the operation                                                      |
 | `@ignore`                  | Exclude a route from generation                                                                         |
+| `@internal`                | Exclude a schema/type declaration from `components/schemas`                                             |
 | `@method`                  | Required HTTP method tag for Pages Router handlers                                                      |
 
 For the complete tag guide and usage recipes, see

--- a/docs/jsdoc-reference.md
+++ b/docs/jsdoc-reference.md
@@ -645,6 +645,54 @@ export interface AudioInterface {
 In both cases, the component is registered as `Audio` and cross-type references resolve correctly
 to `#/components/schemas/Audio`.
 
+## Excluding internal schemas from components
+
+Inline Zod or TypeScript schemas used only as route-internal implementation details (path/query param
+shapes, bulk-payload bounds, etc.) are emitted into `components/schemas` by default. Two mechanisms
+let you suppress them.
+
+### Per-schema: `@internal` JSDoc tag
+
+Add `/** @internal */` as a leading comment on any Zod `const` declaration or TypeScript
+`type`/`interface`:
+
+```ts
+/** @internal */
+const productIdParamsSchema = z.object({
+  id: z.coerce.number().int().positive(),
+});
+
+/** @internal */
+export type ProductIdParams = z.infer<typeof productIdParamsSchema>;
+```
+
+Both forms suppress the schema from `components/schemas`. If the schema is still referenced by a
+route (e.g. via `@pathParams`), the `$ref` is automatically replaced with the inlined schema content
+so the generated spec remains valid.
+
+`@schema false` is accepted as an alias for `@internal`.
+
+### Project-wide: `excludeSchemas` config
+
+Add `excludeSchemas` to your `openapi-gen.config.ts` (or `next.openapi.json`) to exclude schemas by
+exact name or simple glob (`*`):
+
+```ts
+// openapi-gen.config.ts
+export default defineConfig({
+  // ...
+  excludeSchemas: ["*Params", "productBulkSchema"],
+});
+```
+
+| Pattern                   | Matches                           |
+| ------------------------- | --------------------------------- |
+| `"productIdParamsSchema"` | Exact name                        |
+| `"*Params"`               | Any name ending with `Params`     |
+| `"Internal*"`             | Any name starting with `Internal` |
+
+References to excluded schemas in route operations are inlined automatically.
+
 ## Related guides
 
 - [Getting started and configuration](./getting-started.md)

--- a/packages/openapi-core/src/config/normalize.ts
+++ b/packages/openapi-core/src/config/normalize.ts
@@ -132,6 +132,7 @@ export function normalizeOpenApiConfig(
     outputDir: template.outputDir ?? DEFAULT_OUTPUT_DIR,
     includeOpenApiRoutes: template.includeOpenApiRoutes ?? DEFAULT_INCLUDE_OPENAPI_ROUTES,
     ignoreRoutes: template.ignoreRoutes ?? [],
+    excludeSchemas: template.excludeSchemas ?? [],
     schemaType: template.schemaType ?? DEFAULT_RUNTIME_SCHEMA_TYPE,
     schemaBackends,
     schemaFiles: template.schemaFiles ?? [],

--- a/packages/openapi-core/src/core/exclude-schemas.ts
+++ b/packages/openapi-core/src/core/exclude-schemas.ts
@@ -1,0 +1,74 @@
+import { logger } from "../shared/logger.js";
+import type { OpenApiDocument, OpenApiSchema } from "../shared/types.js";
+
+function patternToRegExp(pattern: string): RegExp {
+  const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`^${escaped.replace(/\*/g, ".*")}$`);
+}
+
+export function matchExcludePatterns(names: string[], patterns: string[]): string[] {
+  if (patterns.length === 0) return [];
+  const regexes = patterns.map(patternToRegExp);
+  return names.filter((name) => regexes.some((re) => re.test(name)));
+}
+
+export function applyExcludeSchemas(
+  document: OpenApiDocument,
+  mergedSchemas: Record<string, unknown>,
+  excludedSchemas: Record<string, OpenApiSchema>,
+): void {
+  const excludedNames = new Set(Object.keys(excludedSchemas));
+  if (excludedNames.size === 0) return;
+
+  walkAndInline(document, excludedSchemas, excludedNames, new Set());
+
+  for (const name of excludedNames) {
+    delete mergedSchemas[name];
+  }
+}
+
+function walkAndInline(
+  obj: unknown,
+  excluded: Record<string, OpenApiSchema>,
+  excludedNames: Set<string>,
+  visiting: Set<string>,
+): void {
+  if (!obj || typeof obj !== "object") return;
+
+  if (Array.isArray(obj)) {
+    for (const item of obj) {
+      walkAndInline(item, excluded, excludedNames, visiting);
+    }
+    return;
+  }
+
+  const rec = obj as Record<string, unknown>;
+  const ref = rec["$ref"];
+
+  if (typeof ref === "string") {
+    const match = ref.match(/^#\/components\/schemas\/(.+)$/);
+    const name = match?.[1];
+    if (name && excludedNames.has(name)) {
+      if (visiting.has(name)) {
+        logger.warn(`Circular reference to internal schema "${name}", keeping $ref`);
+        return;
+      }
+      const schemaDef = excluded[name];
+      if (schemaDef) {
+        const cloned = JSON.parse(JSON.stringify(schemaDef)) as Record<string, unknown>;
+        delete rec["$ref"];
+        Object.assign(rec, cloned);
+        const newVisiting = new Set(visiting);
+        newVisiting.add(name);
+        for (const key of Object.keys(rec)) {
+          walkAndInline(rec[key], excluded, excludedNames, newVisiting);
+        }
+        return;
+      }
+    }
+  }
+
+  for (const key of Object.keys(rec)) {
+    walkAndInline(rec[key], excluded, excludedNames, visiting);
+  }
+}

--- a/packages/openapi-core/src/core/orchestrator.ts
+++ b/packages/openapi-core/src/core/orchestrator.ts
@@ -22,6 +22,7 @@ import {
   type GenerationPerformanceProfile,
 } from "./performance.js";
 import type { SharedGenerationRuntime } from "./runtime.js";
+import { applyExcludeSchemas, matchExcludePatterns } from "./exclude-schemas.js";
 export type OrchestratorPerformanceProfile = GenerationPerformanceProfile & {
   scanRoutesMs: number;
 };
@@ -132,11 +133,28 @@ export function runGenerationOrchestrator({
   profile.defaultComponentsAndErrorsMs = performance.now() - phaseStartedAt;
 
   phaseStartedAt = performance.now();
-  const definedSchemas = routeProcessor.getSchemaProcessor().getDefinedSchemas();
+  const schemaProcessor = routeProcessor.getSchemaProcessor();
+  const definedSchemas = schemaProcessor.getDefinedSchemas();
   const mergedSchemas: Record<string, unknown> = {
     ...document.components.schemas,
     ...definedSchemas,
   };
+
+  const internalSchemas = schemaProcessor.getInternalSchemas();
+  const patternExcludedNames = matchExcludePatterns(
+    Object.keys(mergedSchemas),
+    config.excludeSchemas ?? [],
+  );
+  const allExcludedSchemas = {
+    ...internalSchemas,
+    ...Object.fromEntries(
+      patternExcludedNames.map((name) => [name, mergedSchemas[name] as Record<string, unknown>]),
+    ),
+  };
+  if (Object.keys(allExcludedSchemas).length > 0) {
+    applyExcludeSchemas(document, mergedSchemas, allExcludedSchemas);
+  }
+
   if (Object.keys(mergedSchemas).length > 0) {
     document.components.schemas = Object.fromEntries(
       Object.entries(mergedSchemas).sort(([a], [b]) =>

--- a/packages/openapi-core/src/schema/typescript/schema-discovery.ts
+++ b/packages/openapi-core/src/schema/typescript/schema-discovery.ts
@@ -4,7 +4,10 @@ import * as t from "@babel/types";
 
 import { traverse } from "../../shared/babel-traverse.js";
 import { resolveTypeScriptModule } from "../../shared/typescript-project.js";
-import { extractSchemaIdFromComments } from "../../shared/utils.js";
+import {
+  extractInternalFlagFromComments,
+  extractSchemaIdFromComments,
+} from "../../shared/utils.js";
 
 type TypeDefinitions = Record<string, any>;
 
@@ -116,6 +119,7 @@ export function collectAllExportedDefinitions(
   typeDefinitions: TypeDefinitions,
   currentFile: string,
   schemaIdAliases?: Record<string, string>,
+  internalSchemaNames?: Set<string>,
 ): void {
   function registerDefinition(
     name: string,
@@ -131,6 +135,9 @@ export function collectAllExportedDefinitions(
       if (!typeDefinitions[overrideId]) {
         typeDefinitions[overrideId] = entry;
       }
+    }
+    if (internalSchemaNames && extractInternalFlagFromComments(allComments)) {
+      internalSchemaNames.add(name);
     }
   }
 

--- a/packages/openapi-core/src/schema/typescript/schema-processor.ts
+++ b/packages/openapi-core/src/schema/typescript/schema-processor.ts
@@ -84,6 +84,7 @@ export class SchemaProcessor {
   private schemaTypes: SchemaType[];
   private isResolvingPickOmitBase: boolean = false;
   private schemaIdAliases: Record<string, string> = {};
+  private internalSchemaNames: Set<string> = new Set();
   private readonly fileAccess: SchemaProcessorFileAccess;
   private readonly symbolResolver: SymbolResolver;
 
@@ -147,7 +148,8 @@ export class SchemaProcessor {
         !this.isGenericTypeParameter(key) &&
         !this.isInvalidSchemaName(key) &&
         !this.isBuiltInUtilityType(key) &&
-        !this.isFunctionSchema(key)
+        !this.isFunctionSchema(key) &&
+        !this.internalSchemaNames.has(key)
       ) {
         filteredSchemas[key] = value;
       }
@@ -158,6 +160,21 @@ export class SchemaProcessor {
       this.zodSchemaProcessor?.getDefinedSchemas(),
       this.customSchemaProcessor.getDefinedSchemas(),
     ]);
+  }
+
+  public getInternalSchemas(): Record<string, OpenAPIDefinition> {
+    const result: Record<string, OpenAPIDefinition> = {};
+    for (const name of this.internalSchemaNames) {
+      const def = this.openapiDefinitions[name];
+      if (def) result[name] = def;
+    }
+    if (this.zodSchemaConverter) {
+      for (const name of this.zodSchemaConverter.internalSchemaNames) {
+        const schema = this.zodSchemaConverter.zodSchemas[name];
+        if (schema) result[name] = schema;
+      }
+    }
+    return result;
   }
 
   public findSchemaDefinition(schemaName: string, contentType: ContentType): OpenAPIDefinition {
@@ -354,6 +371,7 @@ export class SchemaProcessor {
       this.typeDefinitions,
       filePath || this.currentFilePath,
       this.schemaIdAliases,
+      this.internalSchemaNames,
     );
   }
 

--- a/packages/openapi-core/src/schema/zod/zod-converter.ts
+++ b/packages/openapi-core/src/schema/zod/zod-converter.ts
@@ -4,7 +4,7 @@ import type { NodePath } from "@babel/traverse";
 import * as t from "@babel/types";
 
 import { traverse } from "../../shared/babel-traverse.js";
-import { parseTypeScriptFile } from "../../shared/utils.js";
+import { extractInternalFlagFromComments, parseTypeScriptFile } from "../../shared/utils.js";
 import { logger } from "../../shared/logger.js";
 import { SymbolResolver } from "../../shared/symbol-resolver.js";
 import { DrizzleZodProcessor } from "./drizzle-zod-processor.js";
@@ -78,6 +78,8 @@ export class ZodSchemaConverter {
   /** Schema variable names whose component name was overridden via .meta({ id }). These must
    *  NOT be copied back under the original variable name in the OpenAPI components object. */
   metaIdSchemaNames: Set<string> = new Set();
+  /** Schema variable names marked @internal — excluded from components/schemas output. */
+  internalSchemaNames: Set<string> = new Set();
   // Current processing context (set during file processing)
   currentFilePath?: string;
   currentAST?: t.File;
@@ -2272,7 +2274,13 @@ export class ZodSchemaConverter {
    * Get all processed Zod schemas
    */
   getProcessedSchemas(): Record<string, OpenApiSchema> {
-    return this.zodSchemas;
+    const result: Record<string, OpenApiSchema> = {};
+    for (const [name, schema] of Object.entries(this.zodSchemas)) {
+      if (!this.internalSchemaNames.has(name)) {
+        result[name] = schema;
+      }
+    }
+    return result;
   }
 
   /**
@@ -2346,6 +2354,15 @@ export class ZodSchemaConverter {
 
                 // Check if is Zod schema
                 if (this.isZodSchema(declaration.init)) {
+                  const decl = path.node.declaration;
+                  const allComments = [
+                    ...(path.node.leadingComments ?? []),
+                    ...(decl?.leadingComments ?? []),
+                    ...(declaration.leadingComments ?? []),
+                  ];
+                  if (extractInternalFlagFromComments(allComments)) {
+                    this.internalSchemaNames.add(schemaName);
+                  }
                   if (!this.getStoredSchema(schemaName)) {
                     logger.debug(`Pre-processing Zod schema: ${schemaName}`);
                     this.processingSchemas.add(schemaName);
@@ -2371,6 +2388,13 @@ export class ZodSchemaConverter {
             if (t.isIdentifier(declaration.id) && declaration.init) {
               const schemaName = declaration.id.name;
               if (this.isZodSchema(declaration.init)) {
+                const allComments = [
+                  ...(path.node.leadingComments ?? []),
+                  ...(declaration.leadingComments ?? []),
+                ];
+                if (extractInternalFlagFromComments(allComments)) {
+                  this.internalSchemaNames.add(schemaName);
+                }
                 if (!this.getStoredSchema(schemaName) && !this.processingSchemas.has(schemaName)) {
                   logger.debug(`Pre-processing Zod schema: ${schemaName}`);
                   this.processingSchemas.add(schemaName);

--- a/packages/openapi-core/src/shared/types.ts
+++ b/packages/openapi-core/src/shared/types.ts
@@ -63,6 +63,7 @@ export type OpenApiConfig = {
   outputDir: string;
   includeOpenApiRoutes: boolean;
   ignoreRoutes?: string[] | undefined;
+  excludeSchemas?: string[] | undefined;
   schemaType: SchemaType | SchemaType[]; // Support both single type and array of types
   schemaFiles?: string[] | undefined; // Array of custom OpenAPI schema files (YAML/JSON)
   defaultResponseSet?: string | undefined;
@@ -173,6 +174,7 @@ export type OpenApiTemplate = OpenApiDocument & {
   outputDir?: string | undefined;
   includeOpenApiRoutes?: boolean | undefined;
   ignoreRoutes?: string[] | undefined;
+  excludeSchemas?: string[] | undefined;
   schemaType?: SchemaType | SchemaType[] | undefined;
   schemaFiles?: string[] | undefined;
   defaultResponseSet?: string | undefined;

--- a/packages/openapi-core/src/shared/utils.ts
+++ b/packages/openapi-core/src/shared/utils.ts
@@ -1025,6 +1025,7 @@ const INTERNAL_OPENAPI_CONFIG_KEYS = [
   "diagnostics",
   "debug",
   "authPresets",
+  "excludeSchemas",
 ] as const;
 
 export const DEFAULT_AUTH_PRESET_REPLACEMENTS: Record<string, string> = {

--- a/packages/openapi-core/src/shared/utils.ts
+++ b/packages/openapi-core/src/shared/utils.ts
@@ -562,6 +562,19 @@ export function cleanComment(commentValue: string): string {
   return commentValue.replace(/\*\s*/g, "").trim();
 }
 
+export function extractInternalFlagFromComments(
+  comments: ReadonlyArray<{ type: string; value: string }> | null | undefined,
+): boolean {
+  if (!comments) return false;
+  for (const comment of comments) {
+    const cleaned = cleanComment(comment.value);
+    if (/@internal\b/.test(cleaned) || /@schema\s+false\b/.test(cleaned)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 export function extractSchemaIdFromComments(
   comments: ReadonlyArray<{ type: string; value: string }> | null | undefined,
 ): string | null {

--- a/tests/integration/generator/exclude-schemas.test.ts
+++ b/tests/integration/generator/exclude-schemas.test.ts
@@ -1,0 +1,200 @@
+import fs from "node:fs";
+
+import { describe, expect, it } from "vitest";
+import { createDefaultGenerationAdapters } from "@workspace/openapi-cli";
+
+import { runGenerationOrchestrator } from "@workspace/openapi-core/core/orchestrator.js";
+import { normalizeOpenApiConfig } from "@workspace/openapi-core/config/normalize.js";
+
+import {
+  createTempProject,
+  withProjectCwd,
+  writeAppRoute,
+  writeOpenApiTemplate,
+} from "../../helpers/test-project.js";
+
+function generateSpec(routeContent: string, templateOverrides: Record<string, unknown> = {}) {
+  const project = createTempProject("nxog-exclude-schemas-");
+
+  try {
+    const templatePath = writeOpenApiTemplate(project.root, templateOverrides);
+    writeAppRoute(project.root, ["products", "[id]"], routeContent);
+
+    return withProjectCwd(project.root, () => {
+      const template = JSON.parse(fs.readFileSync(templatePath, "utf8"));
+      const config = normalizeOpenApiConfig(template);
+      const adapters = createDefaultGenerationAdapters();
+
+      const result = runGenerationOrchestrator({
+        config,
+        createFrameworkSource: adapters.createFrameworkSource,
+        template,
+      });
+
+      return { result, project };
+    });
+  } catch (err) {
+    project.cleanup();
+    throw err;
+  }
+}
+
+describe("excludeSchemas config option", () => {
+  it("excludes schemas matching exact name", () => {
+    const { result, project } = generateSpec(
+      `
+import { z } from "zod";
+
+const productIdParamsSchema = z.object({ id: z.coerce.number().int().positive() });
+export type ProductIdParams = z.infer<typeof productIdParamsSchema>;
+
+const productSchema = z.object({ id: z.number(), name: z.string() });
+export type Product = z.infer<typeof productSchema>;
+
+/**
+ * @openapi
+ * @pathParams ProductIdParams
+ * @response 200 : Product : OK
+ */
+export async function GET() {}
+`,
+      { excludeSchemas: ["productIdParamsSchema", "ProductIdParams"] },
+    );
+
+    try {
+      const schemas = result.document.components?.schemas ?? {};
+      expect(schemas).not.toHaveProperty("productIdParamsSchema");
+      expect(schemas).not.toHaveProperty("ProductIdParams");
+      expect(schemas).toHaveProperty("Product");
+    } finally {
+      project.cleanup();
+    }
+  });
+
+  it("excludes schemas matching wildcard *Params pattern", () => {
+    const { result, project } = generateSpec(
+      `
+import { z } from "zod";
+
+const productIdParamsSchema = z.object({ id: z.coerce.number().int().positive() });
+export type ProductIdParams = z.infer<typeof productIdParamsSchema>;
+
+const productSchema = z.object({ id: z.number(), name: z.string() });
+export type Product = z.infer<typeof productSchema>;
+
+/**
+ * @openapi
+ * @pathParams ProductIdParams
+ * @response 200 : Product : OK
+ */
+export async function GET() {}
+`,
+      { excludeSchemas: ["*Params"] },
+    );
+
+    try {
+      const schemas = result.document.components?.schemas ?? {};
+      expect(schemas).not.toHaveProperty("ProductIdParams");
+      expect(schemas).toHaveProperty("Product");
+    } finally {
+      project.cleanup();
+    }
+  });
+});
+
+describe("@internal JSDoc tag on Zod schemas", () => {
+  it("excludes Zod schema marked @internal from components", () => {
+    const { result, project } = generateSpec(`
+import { z } from "zod";
+
+/** @internal */
+const productIdParamsSchema = z.object({ id: z.coerce.number().int().positive() });
+export type ProductIdParams = z.infer<typeof productIdParamsSchema>;
+
+const productSchema = z.object({ id: z.number(), name: z.string() });
+export type Product = z.infer<typeof productSchema>;
+
+/**
+ * @openapi
+ * @pathParams ProductIdParams
+ * @response 200 : Product : OK
+ */
+export async function GET() {}
+`);
+
+    try {
+      const schemas = result.document.components?.schemas ?? {};
+      expect(schemas).not.toHaveProperty("productIdParamsSchema");
+      expect(schemas).toHaveProperty("Product");
+    } finally {
+      project.cleanup();
+    }
+  });
+
+  it("excludes exported Zod const marked @internal", () => {
+    const { result, project } = generateSpec(`
+import { z } from "zod";
+
+/** @internal */
+export const productBulkSchema = z.array(z.object({ id: z.number() })).max(500);
+
+const productSchema = z.object({ id: z.number(), name: z.string() });
+export type Product = z.infer<typeof productSchema>;
+
+/**
+ * @openapi
+ * @response 200 : Product : OK
+ */
+export async function GET() {}
+`);
+
+    try {
+      const schemas = result.document.components?.schemas ?? {};
+      expect(schemas).not.toHaveProperty("productBulkSchema");
+      expect(schemas).toHaveProperty("Product");
+    } finally {
+      project.cleanup();
+    }
+  });
+});
+
+describe("excluded schema ref inlining", () => {
+  it("inlines path param schema content when schema is excluded via config", () => {
+    const { result, project } = generateSpec(
+      `
+import { z } from "zod";
+
+const productIdParamsSchema = z.object({ id: z.coerce.number().int().positive() });
+export type ProductIdParams = z.infer<typeof productIdParamsSchema>;
+
+const productSchema = z.object({ id: z.number(), name: z.string() });
+export type Product = z.infer<typeof productSchema>;
+
+/**
+ * @openapi
+ * @pathParams ProductIdParams
+ * @response 200 : Product : OK
+ */
+export async function GET() {}
+`,
+      { excludeSchemas: ["productIdParamsSchema", "ProductIdParams"] },
+    );
+
+    try {
+      const schemas = result.document.components?.schemas ?? {};
+      expect(schemas).not.toHaveProperty("productIdParamsSchema");
+      expect(schemas).not.toHaveProperty("ProductIdParams");
+
+      const getOp = result.document.paths?.["/products/{id}"]?.get;
+      expect(getOp).toBeDefined();
+
+      const pathParam = getOp?.parameters?.find((p: any) => p.in === "path" && p.name === "id");
+      if (pathParam) {
+        const schema = (pathParam as any).schema;
+        expect(schema).not.toHaveProperty("$ref");
+      }
+    } finally {
+      project.cleanup();
+    }
+  });
+});

--- a/tests/unit/core/exclude-schemas.test.ts
+++ b/tests/unit/core/exclude-schemas.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  applyExcludeSchemas,
+  matchExcludePatterns,
+} from "@workspace/openapi-core/core/exclude-schemas.js";
+import type { OpenApiDocument } from "@workspace/openapi-core/shared/types.js";
+
+describe("matchExcludePatterns", () => {
+  it("returns empty array when no patterns provided", () => {
+    expect(matchExcludePatterns(["Foo", "Bar"], [])).toEqual([]);
+  });
+
+  it("matches exact names", () => {
+    expect(matchExcludePatterns(["Foo", "Bar", "Baz"], ["Bar"])).toEqual(["Bar"]);
+  });
+
+  it("matches wildcard suffix pattern", () => {
+    const result = matchExcludePatterns(
+      ["ProductIdParams", "ProductBulkSchema", "Product", "UserParams"],
+      ["*Params"],
+    );
+    expect(result).toEqual(["ProductIdParams", "UserParams"]);
+  });
+
+  it("matches wildcard prefix pattern", () => {
+    const result = matchExcludePatterns(["InternalFoo", "InternalBar", "Public"], ["Internal*"]);
+    expect(result).toEqual(["InternalFoo", "InternalBar"]);
+  });
+
+  it("matches multiple patterns", () => {
+    const result = matchExcludePatterns(
+      ["ProductParams", "productBulkSchema", "Product", "UserList"],
+      ["*Params", "*List"],
+    );
+    expect(result).toEqual(["ProductParams", "UserList"]);
+  });
+
+  it("does not match partial name without wildcard", () => {
+    expect(matchExcludePatterns(["ProductParams"], ["Params"])).toEqual([]);
+  });
+
+  it("escapes regex special characters in pattern", () => {
+    expect(matchExcludePatterns(["Foo.Bar", "FooBar"], ["Foo.Bar"])).toEqual(["Foo.Bar"]);
+  });
+});
+
+describe("applyExcludeSchemas", () => {
+  it("removes excluded schema from mergedSchemas", () => {
+    const doc = { openapi: "3.0.0", info: { title: "", version: "" } } as OpenApiDocument;
+    const mergedSchemas: Record<string, unknown> = {
+      Product: { type: "object" },
+      InternalParams: { type: "object", properties: { id: { type: "number" } } },
+    };
+    applyExcludeSchemas(doc, mergedSchemas, {
+      InternalParams: { type: "object", properties: { id: { type: "number" } } },
+    });
+    expect(mergedSchemas).not.toHaveProperty("InternalParams");
+    expect(mergedSchemas).toHaveProperty("Product");
+  });
+
+  it("inlines $ref to excluded schema in operation parameters", () => {
+    const doc = {
+      openapi: "3.0.0",
+      info: { title: "", version: "" },
+      paths: {
+        "/products/{id}": {
+          get: {
+            parameters: [
+              {
+                in: "path",
+                name: "id",
+                schema: { $ref: "#/components/schemas/ProductIdParams" },
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenApiDocument;
+    const mergedSchemas: Record<string, unknown> = {
+      Product: { type: "object" },
+      ProductIdParams: { type: "object", properties: { id: { type: "integer" } } },
+    };
+    applyExcludeSchemas(doc, mergedSchemas, {
+      ProductIdParams: { type: "object", properties: { id: { type: "integer" } } },
+    });
+
+    const schema = (doc as any).paths["/products/{id}"].get.parameters[0].schema;
+    expect(schema).toEqual({ type: "object", properties: { id: { type: "integer" } } });
+    expect(schema).not.toHaveProperty("$ref");
+    expect(mergedSchemas).not.toHaveProperty("ProductIdParams");
+  });
+
+  it("inlines $ref in response body", () => {
+    const doc = {
+      openapi: "3.0.0",
+      info: { title: "", version: "" },
+      paths: {
+        "/products": {
+          get: {
+            responses: {
+              200: {
+                content: {
+                  "application/json": {
+                    schema: { $ref: "#/components/schemas/Product" },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    } as unknown as OpenApiDocument;
+    const mergedSchemas: Record<string, unknown> = {
+      Product: { type: "object", properties: { name: { type: "string" } } },
+    };
+    applyExcludeSchemas(doc, mergedSchemas, {
+      Product: { type: "object", properties: { name: { type: "string" } } },
+    });
+
+    const schema = (doc as any).paths["/products"].get.responses[200].content["application/json"]
+      .schema;
+    expect(schema).toEqual({ type: "object", properties: { name: { type: "string" } } });
+    expect(schema).not.toHaveProperty("$ref");
+  });
+
+  it("handles transitive excluded $refs", () => {
+    const doc = {
+      openapi: "3.0.0",
+      info: { title: "", version: "" },
+      paths: {
+        "/items": {
+          get: {
+            responses: {
+              200: {
+                content: {
+                  "application/json": {
+                    schema: { $ref: "#/components/schemas/ItemList" },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    } as unknown as OpenApiDocument;
+    const mergedSchemas: Record<string, unknown> = {
+      ItemList: {
+        type: "array",
+        items: { $ref: "#/components/schemas/ItemParams" },
+      },
+      ItemParams: { type: "object", properties: { id: { type: "integer" } } },
+    };
+    applyExcludeSchemas(doc, mergedSchemas, {
+      ItemList: {
+        type: "array",
+        items: { $ref: "#/components/schemas/ItemParams" },
+      },
+      ItemParams: { type: "object", properties: { id: { type: "integer" } } },
+    });
+
+    const schema = (doc as any).paths["/items"].get.responses[200].content["application/json"]
+      .schema;
+    expect(schema).toEqual({
+      type: "array",
+      items: { type: "object", properties: { id: { type: "integer" } } },
+    });
+    expect(mergedSchemas).not.toHaveProperty("ItemList");
+    expect(mergedSchemas).not.toHaveProperty("ItemParams");
+  });
+
+  it("does nothing when excludedSchemas is empty", () => {
+    const doc = { openapi: "3.0.0", info: { title: "", version: "" } } as OpenApiDocument;
+    const mergedSchemas: Record<string, unknown> = { Product: { type: "object" } };
+    applyExcludeSchemas(doc, mergedSchemas, {});
+    expect(mergedSchemas).toHaveProperty("Product");
+  });
+
+  it("keeps $ref for non-excluded schemas", () => {
+    const doc = {
+      openapi: "3.0.0",
+      info: { title: "", version: "" },
+      paths: {
+        "/products": {
+          get: {
+            responses: {
+              200: {
+                content: {
+                  "application/json": {
+                    schema: { $ref: "#/components/schemas/Product" },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    } as unknown as OpenApiDocument;
+    const mergedSchemas: Record<string, unknown> = {
+      Product: { type: "object" },
+      InternalParams: { type: "object" },
+    };
+    applyExcludeSchemas(doc, mergedSchemas, {
+      InternalParams: { type: "object" },
+    });
+
+    const schema = (doc as any).paths["/products"].get.responses[200].content["application/json"]
+      .schema;
+    expect(schema).toEqual({ $ref: "#/components/schemas/Product" });
+  });
+});

--- a/tests/unit/shared/utils.test.ts
+++ b/tests/unit/shared/utils.test.ts
@@ -5,6 +5,7 @@ import {
   capitalize,
   cleanComment,
   cleanSpec,
+  extractInternalFlagFromComments,
   extractJSDocComments,
   extractTypeFromComment,
   extractPathParameters,
@@ -488,5 +489,41 @@ describe("shared utils", () => {
       responseType: "Unauthorized",
       successCode: "4XX",
     });
+  });
+});
+
+describe("extractInternalFlagFromComments", () => {
+  it("returns false for null comments", () => {
+    expect(extractInternalFlagFromComments(null)).toBe(false);
+  });
+
+  it("returns false for empty comments", () => {
+    expect(extractInternalFlagFromComments([])).toBe(false);
+  });
+
+  it("returns true for @internal tag", () => {
+    expect(extractInternalFlagFromComments([{ type: "CommentBlock", value: "* @internal " }])).toBe(
+      true,
+    );
+  });
+
+  it("returns true for @schema false tag", () => {
+    expect(
+      extractInternalFlagFromComments([{ type: "CommentBlock", value: "* @schema false " }]),
+    ).toBe(true);
+  });
+
+  it("returns false when neither @internal nor @schema false", () => {
+    expect(
+      extractInternalFlagFromComments([{ type: "CommentBlock", value: "* @id MySchema " }]),
+    ).toBe(false);
+  });
+
+  it("returns true when @internal is among multiple tags", () => {
+    expect(
+      extractInternalFlagFromComments([
+        { type: "CommentBlock", value: "* @id MySchema\n * @internal " },
+      ]),
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## Description

Inline Zod/TypeScript schemas used for path/query parameters or bulk payloads are currently always emitted into `components/schemas`, even when they are internal implementation details not intended to be part of the public API surface. This bloats the generated spec and clutters Swagger UI navigation.

This PR implements two complementary mechanisms to suppress internal schemas, as proposed in #138.

### `@internal` JSDoc tag (per-schema)

Add `/** @internal */` as a leading comment on any Zod `const` declaration or TypeScript `type`/`interface`:

```ts
/** @internal */
const productIdParamsSchema = z.object({
  id: z.coerce.number().int().positive(),
});

/** @internal */
export type ProductIdParams = z.infer<typeof productIdParamsSchema>;
```

`@schema false` is accepted as an alias.

### `excludeSchemas` config option (project-wide)

```ts
// openapi-gen.config.ts
export default defineConfig({
  excludeSchemas: ["*Params", "productBulkSchema"],
});
```

Accepts exact names or simple glob patterns (`*`). Mirrors the existing `ignoreRoutes` option.

### Ref inlining

When an excluded schema is still referenced by a route operation (e.g. via `@pathParams`), the `$ref` is automatically replaced with the inlined schema content so the generated spec remains valid. Transitive excluded `$ref`s are resolved recursively; circular references are detected and kept as-is with a warning.

## Type of Change

- [x] ✨ **feat:** New feature

## Checklist

- [x] `pnpm check` passes
- [x] Tested locally (`pnpm test` and `pnpm build` when relevant)
- [x] Documentation updated (if needed)

Closes #138