### PR TITLE
fix(zod): resolve .meta({ id }) references inside z.array() and z.tuple()

### DIFF
--- a/packages/openapi-core/src/schema/zod/runtime-exporter.ts
+++ b/packages/openapi-core/src/schema/zod/runtime-exporter.ts
@@ -108,10 +108,17 @@ export class ZodRuntimeExporter {
           : null;
       case "enum":
         return this.buildEnum(node);
-      case "array":
-        return node.arguments[0] && isProcessableNode(node.arguments[0])
-          ? z.array(this.buildSchema(node.arguments[0]) ?? z.unknown())
-          : z.array(z.unknown());
+      case "array": {
+        const arg = node.arguments[0];
+        if (!arg || !isProcessableNode(arg)) {
+          return z.array(z.unknown());
+        }
+        const itemSchema = this.buildSchema(arg);
+        if (!itemSchema) {
+          return null;
+        }
+        return z.array(itemSchema);
+      }
       case "strictObject": {
         const base = this.buildObject(node);
         return base && typeof (base as any).strict === "function" ? (base as any).strict() : base;
@@ -274,13 +281,17 @@ export class ZodRuntimeExporter {
       return z.tuple([]);
     }
 
-    const items = node.arguments[0].elements.flatMap((element) => {
+    const items: z.ZodTypeAny[] = [];
+    for (const element of node.arguments[0].elements) {
       if (!isProcessableNode(element)) {
-        return [];
+        return null;
       }
       const schema = this.buildSchema(element);
-      return schema ? [schema] : [];
-    });
+      if (!schema) {
+        return null;
+      }
+      items.push(schema);
+    }
 
     return z.tuple(items as []);
   }

--- a/tests/unit/schema/zod/runtime-exporter.test.ts
+++ b/tests/unit/schema/zod/runtime-exporter.test.ts
@@ -226,6 +226,29 @@ describe("ZodRuntimeExporter", () => {
         prefixItems: [{ type: "string" }, { type: "number" }],
       });
     });
+
+    it("returns null for z.array(identifierReference) so AST path can resolve the $ref", () => {
+      expect(
+        exporter.exportSchema(parseInitializer("z.array(someSchema)"), { contentType: "response" }),
+      ).toBeNull();
+    });
+
+    it("returns null for z.array(identifierReference).meta({...}) so AST path resolves the $ref", () => {
+      expect(
+        exporter.exportSchema(
+          parseInitializer('z.array(someSchema).meta({ description: "items" })'),
+          { contentType: "response" },
+        ),
+      ).toBeNull();
+    });
+
+    it("returns null for z.tuple([identifierReference]) so AST path resolves the $ref", () => {
+      expect(
+        exporter.exportSchema(parseInitializer("z.tuple([someSchema])"), {
+          contentType: "response",
+        }),
+      ).toBeNull();
+    });
   });
 
   describe("union and intersection", () => {

--- a/tests/unit/schema/zod/zod-converter.test.ts
+++ b/tests/unit/schema/zod/zod-converter.test.ts
@@ -596,5 +596,52 @@ describe("ZodSchemaConverter", () => {
       });
       expect(converter.zodSchemas["Shared"]).not.toHaveProperty("properties.b");
     });
+
+    it("emits $ref to meta-id name when schema is referenced inside z.array()", () => {
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), "nxog-zod-meta-id-array-"));
+      roots.push(root);
+
+      fs.writeFileSync(
+        path.join(root, "schemas.ts"),
+        [
+          'import { z } from "zod";',
+          'export const apiErrorIssueSchema = z.object({ path: z.string(), message: z.string() }).meta({ id: "ApiErrorIssue" });',
+          'export const apiErrorSchema = z.object({ message: z.string(), issues: z.array(apiErrorIssueSchema) }).meta({ id: "ApiError" });',
+        ].join("\n"),
+      );
+
+      const converter = new ZodSchemaConverter(root);
+      converter.convertZodSchemaToOpenApi("apiErrorSchema");
+
+      expect(converter.zodSchemas["ApiError"]).toBeDefined();
+      expect(converter.zodSchemas["ApiError"]?.properties?.issues).toMatchObject({
+        type: "array",
+        items: { $ref: "#/components/schemas/ApiErrorIssue" },
+      });
+      expect(converter.zodSchemas["ApiErrorIssue"]).toBeDefined();
+    });
+
+    it("emits $ref to meta-id name when schema is referenced inside z.array().optional()", () => {
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), "nxog-zod-meta-id-array-opt-"));
+      roots.push(root);
+
+      fs.writeFileSync(
+        path.join(root, "schemas.ts"),
+        [
+          'import { z } from "zod";',
+          'export const apiErrorIssueSchema = z.object({ path: z.string() }).meta({ id: "ApiErrorIssue" });',
+          'export const apiErrorSchema = z.object({ issues: z.array(apiErrorIssueSchema).optional() }).meta({ id: "ApiError" });',
+        ].join("\n"),
+      );
+
+      const converter = new ZodSchemaConverter(root);
+      converter.convertZodSchemaToOpenApi("apiErrorSchema");
+
+      expect(converter.zodSchemas["ApiError"]).toBeDefined();
+      expect(converter.zodSchemas["ApiError"]?.properties?.issues).toMatchObject({
+        type: "array",
+        items: { $ref: "#/components/schemas/ApiErrorIssue" },
+      });
+    });
   });
 });


### PR DESCRIPTION
## Description

When a Zod schema is registered under a custom component name via `.meta({ id: 'PascalCaseName' })` and then referenced as an array item inside another `.meta()`-decorated schema, the generated OpenAPI spec emits `items: {}` instead of `items: { "$ref": "#/components/schemas/PascalCaseName" }`.

**Reproduction (from issue #137):**

```ts
export const apiErrorIssueSchema = z
  .object({ path: z.array(z.string()), message: z.string() })
  .meta({ id: 'ApiErrorIssue' });

export const apiErrorSchema = z
  .object({ message: z.string(), issues: z.array(apiErrorIssueSchema).optional() })
  .meta({ id: 'ApiError' });
```

Previously produced `"issues": { "type": "array", "items": {} }`.

**Root cause:** `ZodRuntimeExporter.buildRootSchema` handles schemas rooted in `.meta()`/`.pipe()` chains by rebuilding them at runtime. In the `case "array"` branch, when the array argument is a bare identifier (another schema variable), `buildSchema(arg)` returns `null` (identifiers are not call expressions). The `?? z.unknown()` fallback silently swallowed this null, producing `z.array(z.unknown())` → `items: {}`.

The other helpers (`buildObject`, `buildUnion`, `buildIntersection`, `buildRecord`, …) already return `null` on unresolvable children, causing `exportSchema` to return `null` and fall back to the AST path — which correctly resolves the renamed component via `typeToSchemaMapping` / `getSchemaReferenceName`. The `case "array"` and `buildTuple` are now made consistent: bail out with `null` when a child schema is unresolvable.

## Type of Change

- [x] 🐛 **fix:** Bug fix

## Checklist

- [x] `pnpm check` passes
- [x] Tested locally (`pnpm test` and `pnpm build` when relevant)
- [x] Documentation updated (if needed)

Closes #137