### PR TITLE
fix(zod): restore file context before each processZodNode call in preprocessAllSchemasInFile

### DIFF
--- a/packages/openapi-core/src/schema/zod/zod-converter.ts
+++ b/packages/openapi-core/src/schema/zod/zod-converter.ts
@@ -2349,6 +2349,11 @@ export class ZodSchemaConverter {
                   if (!this.getStoredSchema(schemaName)) {
                     logger.debug(`Pre-processing Zod schema: ${schemaName}`);
                     this.processingSchemas.add(schemaName);
+                    // Restore context in case a recursive preprocessAllSchemasInFile call
+                    // (triggered by processZodNode resolving an import) overwrote these fields.
+                    this.currentFilePath = filePath;
+                    this.currentAST = ast;
+                    this.currentImports = importedModules;
                     const schema = this.processZodNode(declaration.init);
                     this.processingSchemas.delete(schemaName);
                     if (schema) {
@@ -2374,6 +2379,11 @@ export class ZodSchemaConverter {
                 if (!this.getStoredSchema(schemaName) && !this.processingSchemas.has(schemaName)) {
                   logger.debug(`Pre-processing Zod schema: ${schemaName}`);
                   this.processingSchemas.add(schemaName);
+                  // Restore context in case a recursive preprocessAllSchemasInFile call
+                  // (triggered by processZodNode resolving an import) overwrote these fields.
+                  this.currentFilePath = filePath;
+                  this.currentAST = ast;
+                  this.currentImports = importedModules;
                   const schema = this.processZodNode(declaration.init);
                   this.processingSchemas.delete(schemaName);
                   if (schema) {

--- a/tests/integration/regressions/zod-structure-regressions.test.ts
+++ b/tests/integration/regressions/zod-structure-regressions.test.ts
@@ -122,4 +122,50 @@ describe("Zod structure regressions", () => {
       fs.rmSync(testDir, { recursive: true, force: true });
     }
   });
+
+  it("preserves spread base-shape properties when file also imports external schemas", () => {
+    const testDir = createTestDir("nxog-spread-import-");
+
+    fs.writeFileSync(
+      path.join(testDir, "addressSchema.ts"),
+      `
+        import { z } from "zod";
+        export const addressSchema = z.object({
+          street: z.string().describe("Street name"),
+        });
+      `.trim(),
+    );
+
+    fs.writeFileSync(
+      path.join(testDir, "base.ts"),
+      `
+        import { z } from "zod";
+        import { addressSchema } from "./addressSchema";
+
+        const personBaseShape = {
+          name: z.string().describe("Full name"),
+          age: z.number().int().describe("Age in years"),
+        };
+
+        export const employeeSchema = z
+          .object({
+            ...personBaseShape,
+            role: z.string().describe("Job role"),
+          })
+          .meta({ id: "Employee" });
+      `.trim(),
+    );
+
+    try {
+      const converter = new ZodSchemaConverter(testDir);
+      const schema = converter.convertZodSchemaToOpenApi("Employee");
+
+      expect(schema?.properties?.name).toBeDefined();
+      expect(schema?.properties?.age).toBeDefined();
+      expect(schema?.properties?.role).toBeDefined();
+      expect(schema?.required).toEqual(expect.arrayContaining(["name", "age", "role"]));
+    } finally {
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Description

Fixes a bug where spread properties from a non-exported base shape were silently dropped from the generated OpenAPI output when the same schema file also imported external schemas.

**Root cause:** In `preprocessAllSchemasInFile`, `this.currentFilePath`, `this.currentAST`, and `this.currentImports` were set once before the traversal began. When `processZodNode` resolved an imported schema it triggered a recursive call to `preprocessAllSchemasInFile` for that imported file, which overwrote those three fields. After returning from the recursive call, subsequent `processZodNode` invocations in the *original* file used the wrong file context — `resolveConstObjectNode` searched in the imported file and found nothing, so every spread was silently dropped.

**Fix:** Restore `this.currentFilePath`, `this.currentAST`, and `this.currentImports` immediately before each `processZodNode` call inside both traversal visitors (`ExportNamedDeclaration` and `VariableDeclaration`) so the correct context is always active regardless of what recursive preprocessing happened in between.

Closes #147

## Type of Change

- [x] 🐛 **fix:** Bug fix

## Checklist

- [x] `pnpm check` passes
- [x] Tested locally (`pnpm test` and `pnpm build` when relevant)
- [x] Documentation updated (if needed)