### PR TITLE
fix(core): inline excluded $refs nested inside other component schemas

### DIFF
--- a/packages/openapi-core/src/core/exclude-schemas.ts
+++ b/packages/openapi-core/src/core/exclude-schemas.ts
@@ -21,6 +21,7 @@ export function applyExcludeSchemas(
   if (excludedNames.size === 0) return;
 
   walkAndInline(document, excludedSchemas, excludedNames, new Set());
+  walkAndInline(mergedSchemas, excludedSchemas, excludedNames, new Set());
 
   for (const name of excludedNames) {
     delete mergedSchemas[name];

--- a/tests/unit/core/exclude-schemas.test.ts
+++ b/tests/unit/core/exclude-schemas.test.ts
@@ -169,6 +169,34 @@ describe("applyExcludeSchemas", () => {
     expect(mergedSchemas).not.toHaveProperty("ItemParams");
   });
 
+  it("inlines $ref to excluded schema inside another mergedSchemas entry", () => {
+    const doc = { openapi: "3.0.0", info: { title: "", version: "" } } as OpenApiDocument;
+    const internalSchema = {
+      type: "object",
+      properties: { id: { type: "integer" } },
+    };
+    const mergedSchemas: Record<string, unknown> = {
+      PublicEnvelope: {
+        type: "object",
+        properties: {
+          item: { $ref: "#/components/schemas/InternalItem" },
+        },
+      },
+      InternalItem: internalSchema,
+    };
+    applyExcludeSchemas(doc, mergedSchemas, {
+      InternalItem: internalSchema,
+    });
+
+    expect(mergedSchemas).not.toHaveProperty("InternalItem");
+    expect(mergedSchemas.PublicEnvelope).toEqual({
+      type: "object",
+      properties: {
+        item: { type: "object", properties: { id: { type: "integer" } } },
+      },
+    });
+  });
+
   it("does nothing when excludedSchemas is empty", () => {
     const doc = { openapi: "3.0.0", info: { title: "", version: "" } } as OpenApiDocument;
     const mergedSchemas: Record<string, unknown> = { Product: { type: "object" } };


### PR DESCRIPTION
# Pull Request

## Description

`applyExcludeSchemas` walks `document.paths` to inline `$ref`s to excluded schemas, but it does not walk `mergedSchemas`. When a non-excluded component schema references an excluded one, the excluded schema is removed from `components` while the dangling `$ref` inside the non-excluded sibling stays, producing an invalid OpenAPI document. This PR runs `walkAndInline` on `mergedSchemas` as well, before the deletion. Adds a regression test in `tests/unit/core/exclude-schemas.test.ts` that fails on `main` and passes with this change.

## Type of Change

- [ ] ✨ **feat:** New feature
- [x] 🐛 **fix:** Bug fix
- [ ] 📝 **docs:** Documentation update
- [ ] ♻️ **refactor:** Code refactoring
- [ ] ⚡ **perf:** Performance improvement
- [ ] 💥 **Breaking change** (add `!` after type, e.g., `feat!:`)

## Checklist

- [x] `pnpm check` passes
- [x] Tested locally (`pnpm test` and `pnpm build` when relevant)
- [x] Documentation updated (if needed)