### PR TITLE
fix(zod): prefer AST path for chains containing .meta()

### DIFF
--- a/packages/openapi-core/src/schema/zod/zod-converter.ts
+++ b/packages/openapi-core/src/schema/zod/zod-converter.ts
@@ -1742,7 +1742,7 @@ export class ZodSchemaConverter {
     }
 
     if (t.isMemberExpression(node.callee) && t.isIdentifier(node.callee.property)) {
-      const runtimeMethods = new Set(["pipe", "meta"]);
+      const runtimeMethods = new Set(["pipe"]);
       if (runtimeMethods.has(node.callee.property.name)) {
         return true;
       }
@@ -1942,15 +1942,13 @@ export class ZodSchemaConverter {
         schema.type = "integer";
         break;
       case "positive":
-        schema.minimum = 0;
-        schema.exclusiveMinimum = true;
+        schema.exclusiveMinimum = 0;
         break;
       case "nonnegative":
         schema.minimum = 0;
         break;
       case "negative":
-        schema.maximum = 0;
-        schema.exclusiveMaximum = true;
+        schema.exclusiveMaximum = 0;
         break;
       case "nonpositive":
         schema.maximum = 0;

--- a/tests/unit/schema/zod/features/modifiers.test.ts
+++ b/tests/unit/schema/zod/features/modifiers.test.ts
@@ -168,5 +168,33 @@ describe("Zod features › modifiers", () => {
       expect(result).not.toHaveProperty("id");
       expect(result).toMatchObject({ type: "string" });
     });
+
+    it(".meta() followed by .nullish() keeps metadata on outer schema (not nested in anyOf)", () => {
+      const result = convert(
+        'z.string().describe("Audio title").meta({ example: "Episode 42" }).nullish()',
+        roots,
+      );
+      expect(result).toMatchObject({
+        type: "string",
+        nullable: true,
+        description: "Audio title",
+        example: "Episode 42",
+      });
+      expect(result).not.toHaveProperty("anyOf");
+    });
+
+    it(".meta() followed by .nullable() keeps metadata on outer schema (not nested in anyOf)", () => {
+      const result = convert(
+        'z.number().int().meta({ description: "Count", examples: [42] }).nullable()',
+        roots,
+      );
+      expect(result).toMatchObject({
+        type: "integer",
+        nullable: true,
+        description: "Count",
+        examples: [42],
+      });
+      expect(result).not.toHaveProperty("anyOf");
+    });
   });
 });

--- a/tests/unit/schema/zod/features/number-refinements.test.ts
+++ b/tests/unit/schema/zod/features/number-refinements.test.ts
@@ -20,7 +20,7 @@ describe("Zod features › number refinements", () => {
 
   it("positive() encodes exclusive minimum 0", () => {
     const schema = convert("z.number().positive()", roots);
-    expect(schema).toMatchObject({ type: "number", minimum: 0 });
+    expect(schema).toMatchObject({ type: "number", exclusiveMinimum: 0 });
   });
 
   it("nonnegative() encodes minimum 0", () => {
@@ -32,7 +32,7 @@ describe("Zod features › number refinements", () => {
 
   it("negative() encodes exclusive maximum 0", () => {
     const schema = convert("z.number().negative()", roots);
-    expect(schema).toMatchObject({ type: "number", maximum: 0 });
+    expect(schema).toMatchObject({ type: "number", exclusiveMaximum: 0 });
   });
 
   it("nonpositive() encodes maximum 0", () => {

--- a/tests/unit/schema/zod/zod-converter.test.ts
+++ b/tests/unit/schema/zod/zod-converter.test.ts
@@ -261,7 +261,7 @@ describe("ZodSchemaConverter", () => {
     ).toEqual({
       type: "integer",
       minimum: -9007199254740991,
-      exclusiveMinimum: true,
+      exclusiveMinimum: 0,
       maximum: 9007199254740991,
     });
   });


### PR DESCRIPTION
# Pull Request

## Description

The runtime export path treats any chain containing `.meta()` as a runtime dispatch (`runtimeMethods` set in `shouldUseRuntimeExport`). For chains like `z.string().describe("X").meta({ example: "y" }).nullish()`, the runtime path produces `{ anyOf: [{ type: "string", description: "X", examples: ["y"] }, { type: "null" }] }` — the metadata ends up nested inside one branch, making it invisible to consumers reading the outer schema. The AST path can handle the same chain natively (per #124 for `.meta()` and #145 for `.nullable()`/`.nullish()` on named refs) and produce the flatter form `{ type: "string", nullable: true, description: "X", example: "y" }`, which the version finalizer correctly emits as `type: ["string", "null"]` on OpenAPI 3.1 targets.

This PR drops `"meta"` from `runtimeMethods` so chains containing `.meta()` go through the AST path. Removing the runtime dispatch surfaced that the AST `case "positive"` / `case "negative"` still emit the legacy `minimum: 0, exclusiveMinimum: true` form while the runtime path emitted the JSON-Schema 2020-12 numeric form (`exclusiveMinimum: 0`); both cases are updated to the numeric form to match. The version processor already converts numeric forms back to boolean when targeting OpenAPI 3.0, so no finalization changes are required. The previous `.positive().safe()` test expectation was also semantically wrong — `safe()` overwrote `minimum: 0` with the IEEE-754 lower bound while `exclusiveMinimum: true` kept pointing at the new minimum, losing the "positive" constraint — and is corrected here.

Regression tests added in `tests/unit/schema/zod/features/modifiers.test.ts` for `.meta()` followed by `.nullish()` / `.nullable()` fail on `main` and pass with this change.

## Type of Change

- [ ] ✨ **feat:** New feature
- [x] 🐛 **fix:** Bug fix
- [ ] 📝 **docs:** Documentation update
- [ ] ♻️ **refactor:** Code refactoring
- [ ] ⚡ **perf:** Performance improvement
- [ ] 💥 **Breaking change** (add `!` after type, e.g., `feat!:`)

## Checklist

- [x] `pnpm check` passes
- [x] Tested locally (`pnpm test` and `pnpm build` when relevant)
- [x] Documentation updated (if needed)