### PR TITLE
fix: resolve constant/variable references in chain method arguments

### DIFF
--- a/packages/openapi-core/src/schema/zod/zod-converter.ts
+++ b/packages/openapi-core/src/schema/zod/zod-converter.ts
@@ -1585,6 +1585,54 @@ export class ZodSchemaConverter {
   }
 
   /**
+   * Unwrap a possible `TSAsExpression` / `TSSatisfiesExpression` to get the
+   * underlying expression node.  Returns the node itself when no wrapper is
+   * present.
+   */
+  private unwrapTypeAssertion(node: t.Node | null | undefined): t.Node | undefined {
+    if (!node) return undefined;
+    if (t.isTSAsExpression(node) || t.isTSSatisfiesExpression(node)) {
+      return node.expression;
+    }
+    return node;
+  }
+
+  /**
+   * Resolve a numeric value from a call-expression argument.
+   * Handles: numeric literals, identifier references to const numbers,
+   * and `x as number` / `x satisfies number` wrappers around either.
+   */
+  private resolveNumericArg(arg: t.Node | null | undefined): number | undefined {
+    if (!arg) return undefined;
+    const node = this.unwrapTypeAssertion(arg);
+    if (t.isNumericLiteral(node)) return node.value;
+    if (t.isUnaryExpression(node) && node.operator === "-" && t.isNumericLiteral(node.argument)) {
+      return -node.argument.value;
+    }
+    if (t.isIdentifier(node)) {
+      const val = this.resolveLiteralValue(node.name);
+      if (typeof val === "number") return val;
+    }
+    return undefined;
+  }
+
+  /**
+   * Resolve a string value from a call-expression argument.
+   * Handles: string literals, identifier references to const strings,
+   * and `x as string` / `x satisfies string` wrappers around either.
+   */
+  private resolveStringArg(arg: t.Node | null | undefined): string | undefined {
+    if (!arg) return undefined;
+    const node = this.unwrapTypeAssertion(arg);
+    if (t.isStringLiteral(node)) return node.value;
+    if (t.isIdentifier(node)) {
+      const val = this.resolveLiteralValue(node.name);
+      if (typeof val === "string") return val;
+    }
+    return undefined;
+  }
+
+  /**
    * Resolve an identifier referring to a `z.object({...})` (or similar) call expression.
    * This lets callers inline the referenced object's shape.
    */
@@ -1668,6 +1716,13 @@ export class ZodSchemaConverter {
     }
     if (t.isNullLiteral(node)) {
       return null;
+    }
+    if (t.isIdentifier(node)) {
+      const val = this.resolveLiteralValue(node.name);
+      if (val !== undefined) return val;
+    }
+    if (t.isTSAsExpression(node) || t.isTSSatisfiesExpression(node)) {
+      return this.extractStaticJsonValue(node.expression);
     }
     if (t.isArrayExpression(node)) {
       const values: unknown[] = [];
@@ -1792,55 +1847,62 @@ export class ZodSchemaConverter {
           schema.nullable = true;
         }
         break;
-      case "describe":
-        if (node.arguments.length > 0 && t.isStringLiteral(node.arguments[0])) {
-          const description = node.arguments[0].value;
+      case "describe": {
+        const descVal = this.resolveStringArg(node.arguments[0]);
+        if (descVal !== undefined) {
           // Check if description includes @deprecated
-          if (description.startsWith("@deprecated")) {
+          if (descVal.startsWith("@deprecated")) {
             schema.deprecated = true;
             // Remove @deprecated from description
-            schema.description = description.replace("@deprecated", "").trim();
+            schema.description = descVal.replace("@deprecated", "").trim();
           } else {
-            schema.description = description;
+            schema.description = descVal;
           }
         }
         break;
+      }
       case "deprecated":
         schema.deprecated = true;
         break;
-      case "min":
-        if (node.arguments.length > 0 && t.isNumericLiteral(node.arguments[0])) {
+      case "min": {
+        const minVal = this.resolveNumericArg(node.arguments[0]);
+        if (minVal !== undefined) {
           if (schema.type === "string") {
-            schema.minLength = node.arguments[0].value;
+            schema.minLength = minVal;
           } else if (schema.type === "number" || schema.type === "integer") {
-            schema.minimum = node.arguments[0].value;
+            schema.minimum = minVal;
           } else if (schema.type === "array") {
-            schema.minItems = node.arguments[0].value;
+            schema.minItems = minVal;
           }
         }
         break;
-      case "max":
-        if (node.arguments.length > 0 && t.isNumericLiteral(node.arguments[0])) {
+      }
+      case "max": {
+        const maxVal = this.resolveNumericArg(node.arguments[0]);
+        if (maxVal !== undefined) {
           if (schema.type === "string") {
-            schema.maxLength = node.arguments[0].value;
+            schema.maxLength = maxVal;
           } else if (schema.type === "number" || schema.type === "integer") {
-            schema.maximum = node.arguments[0].value;
+            schema.maximum = maxVal;
           } else if (schema.type === "array") {
-            schema.maxItems = node.arguments[0].value;
+            schema.maxItems = maxVal;
           }
         }
         break;
-      case "length":
-        if (node.arguments.length > 0 && t.isNumericLiteral(node.arguments[0])) {
+      }
+      case "length": {
+        const lenVal = this.resolveNumericArg(node.arguments[0]);
+        if (lenVal !== undefined) {
           if (schema.type === "string") {
-            schema.minLength = node.arguments[0].value;
-            schema.maxLength = node.arguments[0].value;
+            schema.minLength = lenVal;
+            schema.maxLength = lenVal;
           } else if (schema.type === "array") {
-            schema.minItems = node.arguments[0].value;
-            schema.maxItems = node.arguments[0].value;
+            schema.minItems = lenVal;
+            schema.maxItems = lenVal;
           }
         }
         break;
+      }
       case "nonempty":
         // `z.array(...).nonempty()` → at least one item.
         if (schema.type === "array") {
@@ -1923,21 +1985,27 @@ export class ZodSchemaConverter {
           schema.pattern = node.arguments[0].pattern;
         }
         break;
-      case "startsWith":
-        if (node.arguments.length > 0 && t.isStringLiteral(node.arguments[0])) {
-          schema.pattern = `^${this.escapeRegExp(node.arguments[0].value)}`;
+      case "startsWith": {
+        const swVal = this.resolveStringArg(node.arguments[0]);
+        if (swVal !== undefined) {
+          schema.pattern = `^${this.escapeRegExp(swVal)}`;
         }
         break;
-      case "endsWith":
-        if (node.arguments.length > 0 && t.isStringLiteral(node.arguments[0])) {
-          schema.pattern = `${this.escapeRegExp(node.arguments[0].value)}$`;
+      }
+      case "endsWith": {
+        const ewVal = this.resolveStringArg(node.arguments[0]);
+        if (ewVal !== undefined) {
+          schema.pattern = `${this.escapeRegExp(ewVal)}$`;
         }
         break;
-      case "includes":
-        if (node.arguments.length > 0 && t.isStringLiteral(node.arguments[0])) {
-          schema.pattern = this.escapeRegExp(node.arguments[0].value);
+      }
+      case "includes": {
+        const incVal = this.resolveStringArg(node.arguments[0]);
+        if (incVal !== undefined) {
+          schema.pattern = this.escapeRegExp(incVal);
         }
         break;
+      }
       case "int":
         schema.type = "integer";
         break;
@@ -1963,18 +2031,22 @@ export class ZodSchemaConverter {
         break;
       case "default":
         if (node.arguments.length > 0) {
-          if (t.isStringLiteral(node.arguments[0])) {
-            schema.default = node.arguments[0].value;
-          } else if (t.isNumericLiteral(node.arguments[0])) {
-            schema.default = node.arguments[0].value;
-          } else if (t.isBooleanLiteral(node.arguments[0])) {
-            schema.default = node.arguments[0].value;
-          } else if (t.isNullLiteral(node.arguments[0])) {
+          const defaultArg = this.unwrapTypeAssertion(node.arguments[0]);
+          if (t.isStringLiteral(defaultArg)) {
+            schema.default = defaultArg.value;
+          } else if (t.isNumericLiteral(defaultArg)) {
+            schema.default = defaultArg.value;
+          } else if (t.isBooleanLiteral(defaultArg)) {
+            schema.default = defaultArg.value;
+          } else if (t.isNullLiteral(defaultArg)) {
             schema.default = null;
-          } else if (t.isObjectExpression(node.arguments[0])) {
+          } else if (t.isIdentifier(defaultArg)) {
+            const val = this.resolveLiteralValue(defaultArg.name);
+            if (val !== undefined) schema.default = val;
+          } else if (t.isObjectExpression(defaultArg)) {
             // Try to create a default object, but this might not be complete
             const defaultObj: Record<string, string | number | boolean> = {};
-            node.arguments[0].properties.forEach((prop) => {
+            defaultArg.properties.forEach((prop) => {
               if (
                 t.isObjectProperty(prop) &&
                 (t.isIdentifier(prop.key) || t.isStringLiteral(prop.key)) &&

--- a/packages/openapi-core/src/shared/symbol-resolver.ts
+++ b/packages/openapi-core/src/shared/symbol-resolver.ts
@@ -195,17 +195,62 @@ export class SymbolResolver {
 
   /**
    * Returns a simple literal value (string/number/boolean/null) for a `const` declarator,
-   * or `null` if no such declarator exists.
+   * following imports and re-exports when the name is not declared locally.
    */
   public resolveLiteral(filePath: string, name: string): ResolvedLiteral | undefined {
+    const visited = new Set<string>();
+    return this.resolveLiteralInternal(filePath, name, visited);
+  }
+
+  private resolveLiteralInternal(
+    filePath: string,
+    name: string,
+    visited: Set<string>,
+  ): ResolvedLiteral | undefined {
+    if (visited.has(filePath)) return undefined;
+    visited.add(filePath);
+
     const index = this.getIndex(filePath);
     if (!index) return undefined;
+
     const literal = index.constLiterals.get(name);
-    if (!literal) return undefined;
-    if (t.isStringLiteral(literal)) return literal.value;
-    if (t.isNumericLiteral(literal)) return literal.value;
-    if (t.isBooleanLiteral(literal)) return literal.value;
-    if (t.isNullLiteral(literal)) return null;
+    if (literal) {
+      if (t.isStringLiteral(literal)) return literal.value;
+      if (t.isNumericLiteral(literal)) return literal.value;
+      if (t.isBooleanLiteral(literal)) return literal.value;
+      if (t.isNullLiteral(literal)) return null;
+    }
+
+    // Follow named imports
+    const imports = this.getImports(filePath);
+    const importInfo = imports?.get(name);
+    if (importInfo) {
+      const resolved = this.resolveImportPath(filePath, importInfo.source);
+      if (resolved) {
+        const targetName = importInfo.importedName === "default" ? name : importInfo.importedName;
+        const result = this.resolveLiteralInternal(resolved, targetName, visited);
+        if (result !== undefined) return result;
+      }
+    }
+
+    // Re-exports `export { Foo } from "..."`
+    const reExport = index.namedReExports.get(name);
+    if (reExport) {
+      const resolved = this.resolveImportPath(filePath, reExport.source);
+      if (resolved) {
+        const result = this.resolveLiteralInternal(resolved, reExport.importedName, visited);
+        if (result !== undefined) return result;
+      }
+    }
+
+    // `export * from "..."`
+    for (const starSrc of index.exportsStar) {
+      const resolved = this.resolveImportPath(filePath, starSrc);
+      if (!resolved) continue;
+      const result = this.resolveLiteralInternal(resolved, name, visited);
+      if (result !== undefined) return result;
+    }
+
     return undefined;
   }
 

--- a/tests/unit/schema/zod/zod-converter.test.ts
+++ b/tests/unit/schema/zod/zod-converter.test.ts
@@ -644,4 +644,186 @@ describe("ZodSchemaConverter", () => {
       });
     });
   });
+
+  describe("constant reference resolution in chain methods", () => {
+    it("resolves const numeric references in .min(), .max(), and .length()", () => {
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), "nxog-zod-const-num-"));
+      roots.push(root);
+
+      fs.writeFileSync(
+        path.join(root, "schemas.ts"),
+        [
+          'import { z } from "zod";',
+          "",
+          "const MAX_CHARS = 5000;",
+          "const MAX_ITEMS = 10;",
+          "const MIN_ITEMS = 1;",
+          "const EXACT_LEN = 4;",
+          "const MIN_VAL = 0;",
+          "const MAX_VAL = 100;",
+          "",
+          "export const InputSchema = z.object({",
+          "  texts: z.array(z.string().max(MAX_CHARS)).min(MIN_ITEMS).max(MAX_ITEMS),",
+          "  code: z.string().length(EXACT_LEN),",
+          "  score: z.number().min(MIN_VAL).max(MAX_VAL),",
+          "});",
+        ].join("\n"),
+      );
+
+      const converter = new ZodSchemaConverter(root);
+      converter.processAllSchemasInFile(path.join(root, "schemas.ts"));
+
+      expect(converter.zodSchemas.InputSchema).toEqual({
+        type: "object",
+        properties: {
+          texts: {
+            type: "array",
+            items: { type: "string", maxLength: 5000 },
+            minItems: 1,
+            maxItems: 10,
+          },
+          code: { type: "string", minLength: 4, maxLength: 4 },
+          score: { type: "number", minimum: 0, maximum: 100 },
+        },
+        required: ["texts", "code", "score"],
+      });
+    });
+
+    it("resolves const string references in .describe(), .startsWith(), .endsWith(), .includes()", () => {
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), "nxog-zod-const-str-"));
+      roots.push(root);
+
+      fs.writeFileSync(
+        path.join(root, "schemas.ts"),
+        [
+          'import { z } from "zod";',
+          "",
+          'const FIELD_DESC = "User email address";',
+          'const PREFIX = "http";',
+          'const SUFFIX = ".com";',
+          'const CONTAINS = "@";',
+          "",
+          "export const FieldSchema = z.object({",
+          "  email: z.string().describe(FIELD_DESC),",
+          "  url: z.string().startsWith(PREFIX),",
+          "  domain: z.string().endsWith(SUFFIX),",
+          "  contact: z.string().includes(CONTAINS),",
+          "});",
+        ].join("\n"),
+      );
+
+      const converter = new ZodSchemaConverter(root);
+      converter.processAllSchemasInFile(path.join(root, "schemas.ts"));
+
+      expect(converter.zodSchemas.FieldSchema).toEqual({
+        type: "object",
+        properties: {
+          email: { type: "string", description: "User email address" },
+          url: { type: "string", pattern: "^http" },
+          domain: { type: "string", pattern: "\\.com$" },
+          contact: { type: "string", pattern: "@" },
+        },
+        required: ["email", "url", "domain", "contact"],
+      });
+    });
+
+    it("resolves constants through 'as number' type assertions", () => {
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), "nxog-zod-const-as-"));
+      roots.push(root);
+
+      fs.writeFileSync(
+        path.join(root, "schemas.ts"),
+        [
+          'import { z } from "zod";',
+          "",
+          "const MAX_LEN = 100;",
+          "",
+          "export const Schema = z.object({",
+          "  name: z.string().max(MAX_LEN as number),",
+          "});",
+        ].join("\n"),
+      );
+
+      const converter = new ZodSchemaConverter(root);
+      converter.processAllSchemasInFile(path.join(root, "schemas.ts"));
+
+      expect(converter.zodSchemas.Schema).toEqual({
+        type: "object",
+        properties: {
+          name: { type: "string", maxLength: 100 },
+        },
+        required: ["name"],
+      });
+    });
+
+    it("resolves const references in .default()", () => {
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), "nxog-zod-const-default-"));
+      roots.push(root);
+
+      fs.writeFileSync(
+        path.join(root, "schemas.ts"),
+        [
+          'import { z } from "zod";',
+          "",
+          "const DEFAULT_COUNT = 42;",
+          'const DEFAULT_NAME = "anonymous";',
+          "",
+          "export const Schema = z.object({",
+          "  count: z.number().default(DEFAULT_COUNT),",
+          "  name: z.string().default(DEFAULT_NAME),",
+          "});",
+        ].join("\n"),
+      );
+
+      const converter = new ZodSchemaConverter(root);
+      converter.processAllSchemasInFile(path.join(root, "schemas.ts"));
+
+      expect(converter.zodSchemas.Schema).toEqual({
+        type: "object",
+        properties: {
+          count: { type: "number", default: 42 },
+          name: { type: "string", default: "anonymous" },
+        },
+        required: ["count", "name"],
+      });
+    });
+
+    it("resolves imported constants from another file", () => {
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), "nxog-zod-const-import-"));
+      roots.push(root);
+
+      fs.writeFileSync(
+        path.join(root, "constants.ts"),
+        ["export const MAX_ITEMS = 50;", 'export const DESCRIPTION = "Items list";'].join("\n"),
+      );
+
+      fs.writeFileSync(
+        path.join(root, "schemas.ts"),
+        [
+          'import { z } from "zod";',
+          'import { MAX_ITEMS, DESCRIPTION } from "./constants";',
+          "",
+          "export const ListSchema = z.object({",
+          "  items: z.array(z.string()).max(MAX_ITEMS).describe(DESCRIPTION),",
+          "});",
+        ].join("\n"),
+      );
+
+      const converter = new ZodSchemaConverter(root);
+      converter.processAllSchemasInFile(path.join(root, "schemas.ts"));
+
+      expect(converter.zodSchemas.ListSchema).toEqual({
+        type: "object",
+        properties: {
+          items: {
+            type: "array",
+            items: { type: "string" },
+            maxItems: 50,
+            description: "Items list",
+          },
+        },
+        required: ["items"],
+      });
+    });
+  });
 });


### PR DESCRIPTION
# Pull Request

## Description

Chain methods like `.min()`, `.max()`, `.length()`, `.describe()`, `.startsWith()`, `.endsWith()`, `.includes()`, and `.default()` only resolved literal values (e.g., `.max(5000)`). When a constant reference was passed (e.g., `.max(MAX_CHARS)`), the AST parser saw an `Identifier` node instead of a `NumericLiteral`/`StringLiteral` and silently skipped it.

This adds `resolveNumericArg()` and `resolveStringArg()` helpers that resolve identifiers via the existing `SymbolResolver`, including cross-file imports. Also fixes `resolveLiteral()` in `SymbolResolver` to follow imports/re-exports (matching the pattern of all other `resolve*` methods). Handles `as number`/`satisfies number` type assertion wrappers as well.

## Type of Change

- [ ] ✨ **feat:** New feature
- [x] 🐛 **fix:** Bug fix
- [ ] 📝 **docs:** Documentation update
- [ ] ♻️ **refactor:** Code refactoring
- [ ] ⚡ **perf:** Performance improvement
- [ ] 💥 **Breaking change** (add `!` after type, e.g., `feat!:`)

## Checklist

- [x] `pnpm check` passes
- [x] Tested locally (`pnpm test` and `pnpm build` when relevant)
- [] Documentation updated (if needed)

---

## ⚠️ PR Title Format Required

Your **PR title** must follow [Conventional Commits](https://www.conventionalcommits.org/):

### ✅ Good Examples

```text
feat: add support for multiple schema types
fix: resolve path parameter detection issue
docs: update configuration examples
```

### ❌ Bad Examples

```text
Added feature
Fixed bug
Update README
```

**Why?** We use squash merge - your PR title becomes the commit message and is used for:

- 📊 Auto-generating changelogs
- 🏷️ Version bumping (`feat:` = minor, `fix:` = patch)
- 📖 Clean git history

See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.

---

Thanks for contributing! 🚀