### PR TITLE
fix(core): handle multiple @response and @tag JSDoc annotations (#154)

### DIFF
--- a/apps/next-app-drizzle-zod/public/openapi.json
+++ b/apps/next-app-drizzle-zod/public/openapi.json
@@ -108,7 +108,8 @@
         "summary": "Create author",
         "description": "Creates a new author using drizzle-zod insert schema generation.",
         "tags": [
-          "Authors"
+          "Authors",
+          "Writing"
         ],
         "parameters": [],
         "requestBody": {
@@ -136,6 +137,9 @@
           },
           "401": {
             "$ref": "#/components/responses/401"
+          },
+          "409": {
+            "$ref": "#/components/responses/409"
           },
           "500": {
             "$ref": "#/components/responses/500"
@@ -562,8 +566,8 @@
             "type": "array",
             "items": {
               "type": "integer",
-              "minimum": 0,
-              "exclusiveMinimum": true
+              "exclusiveMinimum": true,
+              "minimum": 0
             },
             "minItems": 1,
             "description": "Author IDs to update"

--- a/apps/next-app-drizzle-zod/src/app/api/authors/route.ts
+++ b/apps/next-app-drizzle-zod/src/app/api/authors/route.ts
@@ -38,7 +38,9 @@ export async function GET(request: NextRequest) {
  * @description Creates a new author using drizzle-zod insert schema generation.
  * @body CreateAuthorSchema
  * @response 201:AuthorResponseSchema
+ * @response 409
  * @tag Authors
+ * @tag Writing
  * @openapi
  */
 export async function POST(request: NextRequest) {

--- a/apps/next-app-sandbox/public/openapi.json
+++ b/apps/next-app-sandbox/public/openapi.json
@@ -56,9 +56,9 @@
           },
           "limit": {
             "type": "integer",
-            "minimum": 0,
             "exclusiveMinimum": true,
-            "description": "Maximum audit rows"
+            "description": "Maximum audit rows",
+            "minimum": 0
           }
         }
       },
@@ -638,9 +638,9 @@
             "required": false,
             "schema": {
               "type": "integer",
-              "minimum": 0,
               "exclusiveMinimum": true,
-              "description": "Maximum audit rows"
+              "description": "Maximum audit rows",
+              "minimum": 0
             },
             "description": "Maximum audit rows"
           }

--- a/apps/next-app-typescript/public/openapi.json
+++ b/apps/next-app-typescript/public/openapi.json
@@ -2850,6 +2850,26 @@
           },
           "500": {
             "$ref": "#/components/responses/500"
+          },
+          "4XX": {
+            "description": "Any client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Any server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       },
@@ -3047,6 +3067,26 @@
           },
           "500": {
             "$ref": "#/components/responses/500"
+          },
+          "4XX": {
+            "description": "Any client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Fallback error envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       },
@@ -3156,6 +3196,16 @@
           },
           "500": {
             "$ref": "#/components/responses/500"
+          },
+          "4XX": {
+            "description": "Any client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       }
@@ -3765,6 +3815,36 @@
           },
           "500": {
             "$ref": "#/components/responses/500"
+          },
+          "4XX": {
+            "description": "Any client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Any server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Fallback error envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       }

--- a/apps/next-app-zod/public/openapi.json
+++ b/apps/next-app-zod/public/openapi.json
@@ -62,16 +62,17 @@
             "description": "Postal code (format: XX-XXX)"
           },
           "country": {
+            "type": "string",
             "default": "Poland",
-            "description": "Country",
-            "type": "string"
+            "description": "Country"
           }
         },
         "required": [
           "street",
           "houseNumber",
           "city",
-          "postalCode"
+          "postalCode",
+          "country"
         ]
       },
       "AdminStatsSchema": {
@@ -1809,7 +1810,6 @@
           "id": {
             "type": "string",
             "format": "uuid",
-            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
             "description": "Category identifier"
           },
           "name": {
@@ -1994,7 +1994,6 @@
           "id": {
             "type": "string",
             "format": "uuid",
-            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
             "description": "Variant identifier"
           },
           "name": {
@@ -2014,15 +2013,14 @@
           "stock": {
             "type": "integer",
             "minimum": 0,
-            "maximum": 9007199254740991,
             "description": "Stock quantity"
           },
           "attributes": {
             "type": "object",
-            "propertyNames": {
+            "additionalProperties": {
               "type": "string"
             },
-            "additionalProperties": {
+            "propertyNames": {
               "type": "string"
             },
             "description": "Variant attributes (color, size, etc.)"
@@ -2920,6 +2918,16 @@
           },
           "500": {
             "$ref": "#/components/responses/500"
+          },
+          "4XX": {
+            "description": "Authorization or validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthErrorResponse"
+                }
+              }
+            }
           }
         }
       },
@@ -3620,6 +3628,36 @@
           },
           "500": {
             "$ref": "#/components/responses/500"
+          },
+          "4XX": {
+            "description": "Any client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Any server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthErrorResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Fallback error envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthErrorResponse"
+                }
+              }
+            }
           }
         }
       },
@@ -4116,6 +4154,26 @@
           },
           "500": {
             "$ref": "#/components/responses/500"
+          },
+          "4XX": {
+            "description": "Any authentication error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthErrorResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Fallback error envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthErrorResponse"
+                }
+              }
+            }
           }
         }
       },
@@ -4167,6 +4225,26 @@
           },
           "500": {
             "$ref": "#/components/responses/500"
+          },
+          "4XX": {
+            "description": "Authentication failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthErrorResponse"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Upstream auth provider failure",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthErrorResponse"
+                }
+              }
+            }
           }
         }
       }
@@ -4557,6 +4635,16 @@
           },
           "500": {
             "$ref": "#/components/responses/500"
+          },
+          "4XX": {
+            "description": "Signature or replay check failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthErrorResponse"
+                }
+              }
+            }
           }
         }
       }

--- a/apps/next-pages-router/public/openapi.json
+++ b/apps/next-pages-router/public/openapi.json
@@ -34,9 +34,9 @@
           },
           "price": {
             "type": "number",
-            "minimum": 0,
             "exclusiveMinimum": true,
-            "description": "Product price"
+            "description": "Product price",
+            "minimum": 0
           },
           "stock": {
             "type": "integer",
@@ -135,9 +135,9 @@
           },
           "price": {
             "type": "number",
-            "minimum": 0,
             "exclusiveMinimum": true,
-            "description": "Product price"
+            "description": "Product price",
+            "minimum": 0
           },
           "stock": {
             "type": "integer",
@@ -714,6 +714,26 @@
                 "description": "Total users in the result set",
                 "schema": {
                   "type": "integer"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Any client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserErrorResponseSchema"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Fallback error envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserErrorResponseSchema"
                 }
               }
             }

--- a/apps/react-router-app/public/openapi.json
+++ b/apps/react-router-app/public/openapi.json
@@ -12,7 +12,6 @@
         "summary": "Get project",
         "description": "",
         "tags": [
-          "s Projects, Workspace",
           "Projects",
           "Workspace"
         ],
@@ -209,9 +208,6 @@
   "tags": [
     {
       "name": "Projects"
-    },
-    {
-      "name": "s Projects, Workspace"
     },
     {
       "name": "Settings"

--- a/apps/tanstack-app/public/openapi.json
+++ b/apps/tanstack-app/public/openapi.json
@@ -45,13 +45,82 @@
         }
       }
     },
+    "/uploads": {
+      "get": {
+        "operationId": "tanstackGetUploadInstructions",
+        "summary": "Load upload instructions.",
+        "description": "",
+        "tags": [
+          "Uploads"
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        }
+      },
+      "post": {
+        "operationId": "tanstackCreateUpload",
+        "summary": "Create an upload record.",
+        "description": "",
+        "tags": [
+          "Uploads"
+        ],
+        "parameters": [],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/AssetUploadInput"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssetUpload"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          }
+        }
+      }
+    },
     "/users/{id}": {
       "get": {
         "operationId": "tanstackGetUserById",
         "summary": "Get user",
         "description": "",
         "tags": [
-          "s Users, Identity",
           "Users",
           "Identity"
         ],
@@ -144,84 +213,11 @@
           }
         }
       }
-    },
-    "/uploads": {
-      "get": {
-        "operationId": "tanstackGetUploadInstructions",
-        "summary": "Load upload instructions.",
-        "description": "",
-        "tags": [
-          "Uploads"
-        ],
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Successful response",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "400": {
-            "$ref": "#/components/responses/400"
-          },
-          "500": {
-            "$ref": "#/components/responses/500"
-          }
-        }
-      },
-      "post": {
-        "operationId": "tanstackCreateUpload",
-        "summary": "Create an upload record.",
-        "description": "",
-        "tags": [
-          "Uploads"
-        ],
-        "parameters": [],
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/AssetUploadInput"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AssetUpload"
-                }
-              }
-            }
-          },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "403": {
-            "$ref": "#/components/responses/403"
-          }
-        }
-      }
     }
   },
   "tags": [
     {
       "name": "Reports"
-    },
-    {
-      "name": "s Users, Identity"
     },
     {
       "name": "Uploads"

--- a/packages/openapi-core/src/shared/utils.ts
+++ b/packages/openapi-core/src/shared/utils.ts
@@ -83,7 +83,6 @@ export function parseJSDocBlock(commentValue: string, filePath?: string): DataTy
   }
 
   result.description = extractLineValue(normalizedComment, "@description");
-  result.tag = extractLineValue(normalizedComment, "@tag");
   result.tagSummary = extractLineValue(normalizedComment, "@tagSummary");
   result.tagKind = extractLineValue(normalizedComment, "@tagKind");
   result.tagParent = extractLineValue(normalizedComment, "@tagParent");
@@ -124,21 +123,37 @@ export function parseJSDocBlock(commentValue: string, filePath?: string): DataTy
     result.responsePrefixEncoding = responsePrefixEncoding;
   }
 
-  const parsedResponse = parseResponseTag(normalizedComment);
-  if (parsedResponse) {
-    result.successCode = parsedResponse.successCode;
-    result.responseType = parsedResponse.responseType;
-    if (!result.responseDescription && parsedResponse.responseDescription) {
-      result.responseDescription = parsedResponse.responseDescription;
+  const responseMatches = [...normalizedComment.matchAll(/@response\s+([^\n\r@]+)/g)];
+  if (responseMatches.length > 0) {
+    const firstRaw = responseMatches[0]?.[1]?.trim();
+    if (firstRaw) {
+      const parsedResponse = parseResponseRawValue(firstRaw);
+      result.successCode = parsedResponse.successCode;
+      result.responseType = parsedResponse.responseType;
+      if (!result.responseDescription && parsedResponse.responseDescription) {
+        result.responseDescription = parsedResponse.responseDescription;
+      }
+    }
+    const extraResponses = responseMatches
+      .slice(1)
+      .map((m) => m[1]?.trim())
+      .filter((t): t is string => Boolean(t));
+    if (extraResponses.length > 0) {
+      result.addResponses = extraResponses.join(",");
     }
   }
 
   const addMatches = [...normalizedComment.matchAll(/@add\s+([^\n\r@]*)/g)];
   if (addMatches.length > 0) {
-    result.addResponses = addMatches
+    const addEntries = addMatches
       .map((match) => match[1]?.trim() || "")
       .filter(Boolean)
       .join(",");
+    if (addEntries) {
+      result.addResponses = result.addResponses
+        ? `${result.addResponses},${addEntries}`
+        : addEntries;
+    }
   }
 
   const examples = collectExampleDefinitions(normalizedComment, "@examples", filePath);
@@ -152,6 +167,21 @@ export function parseJSDocBlock(commentValue: string, filePath?: string): DataTy
   const additionalTags = extractListValue(normalizedComment, "@tags");
   if (additionalTags.length > 0) {
     result.tags = additionalTags;
+  }
+
+  const tagMatches = [...normalizedComment.matchAll(/@tag\s+([^\n\r@]*)/g)];
+  if (tagMatches.length > 0) {
+    const primaryTag = tagMatches[0]?.[1]?.trim();
+    if (primaryTag) {
+      result.tag = primaryTag;
+    }
+    const extraTags = tagMatches
+      .slice(1)
+      .map((m) => m[1]?.trim())
+      .filter((t): t is string => Boolean(t));
+    if (extraTags.length > 0) {
+      result.tags = [...(result.tags ?? []), ...extraTags];
+    }
   }
 
   const servers = parseServersTag(normalizedComment);
@@ -415,11 +445,17 @@ export function parseResponseTag(commentValue: string): {
   successCode: string;
 } | null {
   const rawValue = commentValue.match(/@response\s+([^\n\r@]+)/)?.[1]?.trim();
-
   if (!rawValue) {
     return null;
   }
+  return parseResponseRawValue(rawValue);
+}
 
+function parseResponseRawValue(rawValue: string): {
+  responseDescription: string;
+  responseType: string;
+  successCode: string;
+} {
   if (isStatusCodeToken(rawValue)) {
     return {
       responseDescription: "",

--- a/tests/unit/shared/utils.test.ts
+++ b/tests/unit/shared/utils.test.ts
@@ -411,6 +411,65 @@ describe("shared utils", () => {
     expect(data?.deprecationReason).toBe("use /v2/subscribe instead");
   });
 
+  it("handles multiple @tag annotations by using first as primary and rest as additional tags", () => {
+    const data = getExportCommentData(`
+      /**
+       * @tag Events
+       * @tag Platform
+       * @tag Streaming
+       * @openapi
+       */
+      export async function POST() {}
+    `);
+    expect(data?.tag).toBe("Events");
+    expect(data?.tags).toEqual(["Platform", "Streaming"]);
+  });
+
+  it("handles multiple @response annotations by converting extras to @add entries", () => {
+    const data = getExportCommentData(`
+      /**
+       * @response 200:UserResponse:Success
+       * @response 404:NotFound
+       * @response 429:RateLimitResponse:Too many requests
+       * @openapi
+       */
+      export async function POST() {}
+    `);
+    expect(data?.successCode).toBe("200");
+    expect(data?.responseType).toBe("UserResponse");
+    expect(data?.responseDescription).toBe("Success");
+    expect(data?.addResponses).toBe("404:NotFound,429:RateLimitResponse:Too many requests");
+  });
+
+  it("merges multiple @tag with @tags plural", () => {
+    const data = getExportCommentData(`
+      /**
+       * @tag Events
+       * @tag Platform
+       * @tags Streaming, Webhooks
+       * @openapi
+       */
+      export async function POST() {}
+    `);
+    expect(data?.tag).toBe("Events");
+    expect(data?.tags).toEqual(["Streaming", "Webhooks", "Platform"]);
+  });
+
+  it("merges multiple @response with existing @add entries", () => {
+    const data = getExportCommentData(`
+      /**
+       * @response 200:UserResponse
+       * @response 404:NotFound
+       * @add 401:Unauthorized
+       * @openapi
+       */
+      export async function POST() {}
+    `);
+    expect(data?.successCode).toBe("200");
+    expect(data?.responseType).toBe("UserResponse");
+    expect(data?.addResponses).toBe("404:NotFound,401:Unauthorized");
+  });
+
   it("parses @responseHeader, @link, @callback, and @openapi-override", () => {
     const data = getExportCommentData(`
       /**


### PR DESCRIPTION
## Summary

Fixes #154 — multiple `@response` and `@tag` (singular) annotations in a single JSDoc block were silently ignored; only the first was parsed.

## Root cause

Both `extractLineValue(@tag)` and `parseResponseTag()` used single-match regex (`String.match` without `/g` flag), so subsequent occurrences were dropped.

## Fix

- **`@response`**: use `matchAll` to collect all matches. First → primary success response; extras → converted to `addResponses` and merged with existing `@add` entries.
- **`@tag`**: use `matchAll` to collect all matches. First → primary tag; extras → appended to `tags` array alongside any `@tags` plural entries.
- Extracted `parseResponseRawValue` helper to keep parsing DRY.

## Files changed

| File | Change |
|---|---|
| `packages/openapi-core/src/shared/utils.ts` | Core fix (+45/−9) |
| `tests/unit/shared/utils.test.ts` | 4 new test cases (+59) |
| `apps/next-app-drizzle-zod/src/app/api/authors/route.ts` | Minimal demo (+2) |
| `apps/*/public/openapi.json` | Regenerated (8 files) |

## Testing

- Unit: 721 pass, 0 fail
- Integration: 69 pass, 0 fail