### PR TITLE
fix(init): resolve template directory by walking up from import.meta.url

### DIFF
--- a/packages/openapi-init/src/init/ui-template.ts
+++ b/packages/openapi-init/src/init/ui-template.ts
@@ -5,7 +5,21 @@ import { fileURLToPath } from "node:url";
 import { normalizeRapidocTemplate } from "./rapidoc-template.js";
 import type { InitFramework } from "./framework.js";
 
-const packageRootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+function findPackageRoot(): string {
+  let dir = path.dirname(fileURLToPath(import.meta.url));
+  while (true) {
+    if (fs.existsSync(path.join(dir, "templates", "init", "ui"))) {
+      return dir;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) {
+      throw new Error("Cannot locate templates directory");
+    }
+    dir = parent;
+  }
+}
+
+const packageRootDir = findPackageRoot();
 const uiTemplatesDir = path.join(packageRootDir, "templates", "init", "ui");
 
 type RenderUiTemplateOptions = {


### PR DESCRIPTION
The hardcoded `../../` relative path broke when openapi-init is bundled into the next-openapi-gen CLI by tsup. In the bundle, `import.meta.url` points to `dist/cli.js` (1 level deep), making `../../` resolve one directory too high and miss the `templates/` directory.

Replace the fixed-depth resolution with `findPackageRoot()` that walks up from the current file's directory until it finds `templates/init/ui/`, working correctly in both the standalone openapi-init package and the bundled CLI.

Closes #149