### PR TITLE
fix(test): remove unnecessary non-null assertion in prescan test

### DIFF
--- a/tests/unit/schema/zod/prescan.test.ts
+++ b/tests/unit/schema/zod/prescan.test.ts
@@ -119,9 +119,11 @@ describe("Zod prescan helpers", () => {
       t.isMemberExpression(node.callee) &&
       t.isIdentifier(node.callee.object, { name: "z" });
 
-    expect(returnsZodSchemaNode(findFunctionInAST(currentAST, "makeLocal")!, isZodSchema)).toBe(
-      true,
-    );
+    const makeLocalNode = findFunctionInAST(currentAST, "makeLocal");
+    if (!makeLocalNode) {
+      throw new Error("expected makeLocal function in AST");
+    }
+    expect(returnsZodSchemaNode(makeLocalNode, isZodSchema)).toBe(true);
     expect(returnsZodSchemaNode(t.identifier("value"), isZodSchema)).toBe(false);
     expect(
       returnsZodSchemaNode(


### PR DESCRIPTION
Replaces `findFunctionInAST(...)!` with an explicit null guard to satisfy oxlint's `o-unnecessary-type-assertion` rule, which fired on Linux CI due to OS-specific type-aware resolution differences (pnpm symlinks vs Windows junctions).