### PR TITLE
fix: correct Date expansion and enum-constrained parameter examples

### DIFF
--- a/packages/openapi-core/src/schema/typescript/helpers.ts
+++ b/packages/openapi-core/src/schema/typescript/helpers.ts
@@ -203,9 +203,17 @@ export function getExampleForParam(
   paramName: string,
   typeOrSchema: string | OpenApiSchemaLike = "string",
 ): any {
-  const schema = typeof typeOrSchema === "string" ? { type: typeOrSchema } : typeOrSchema;
+  const schema: OpenApiSchemaLike =
+    typeof typeOrSchema === "string" ? { type: typeOrSchema } : typeOrSchema;
   const type = getPrimaryType(schema.type);
   const format = typeof schema.format === "string" ? schema.format : undefined;
+
+  // A synthesized example has to satisfy the schema it documents. When the schema
+  // enumerates its allowed values, every name-based guess below is invalid by
+  // construction, so the first member is the only safe choice.
+  if (schema.enum && schema.enum.length > 0) {
+    return schema.enum[0];
+  }
 
   if (format === "uuid" || paramName.toLowerCase().includes("uuid")) {
     return "123e4567-e89b-12d3-a456-426614174000";

--- a/packages/openapi-core/src/schema/typescript/schema-processor.ts
+++ b/packages/openapi-core/src/schema/typescript/schema-processor.ts
@@ -19,6 +19,7 @@ import type {
   PropertyOptions,
   SchemaType,
 } from "../../shared/types.js";
+import { isDateType } from "../../shared/typescript-adapter.js";
 import { getTypeScriptAdapter, getTypeScriptProject } from "../../shared/typescript-project.js";
 import type { TypeScriptRuntime } from "../../shared/typescript-runtime.js";
 import { parseOpenApiOverrideTag, parseTypeScriptFile } from "../../shared/utils.js";
@@ -968,6 +969,10 @@ export class SchemaProcessor {
     seen: Set<string>,
     ts: TypeScriptRuntime,
   ): OpenAPIDefinition {
+    if (isDateType(type, checker)) {
+      return { type: "string", format: "date-time" };
+    }
+
     const primitiveLikeFlags =
       ts.TypeFlags.StringLike |
       ts.TypeFlags.NumberLike |

--- a/packages/openapi-core/src/shared/native-typescript-adapter.ts
+++ b/packages/openapi-core/src/shared/native-typescript-adapter.ts
@@ -4,6 +4,7 @@ import os from "os";
 import path from "path";
 
 import type { Diagnostic, InferredResponseDefinition, OpenAPIDefinition } from "./types.js";
+import { isDateType } from "./typescript-adapter.js";
 import type {
   InferredRouteResponses,
   TypeScriptCompilerAdapter,
@@ -836,6 +837,10 @@ class NativeTypeScriptAdapter implements TypeScriptCompilerAdapter {
     project: NativeProjectApi,
     seen: Set<string>,
   ): OpenAPIDefinition {
+    if (isDateType(type, checker)) {
+      return { type: "string", format: "date-time" };
+    }
+
     const typeFlags = this.sync.TypeFlags;
     const primitiveLikeFlags =
       (typeFlags.StringLike ?? 0) |

--- a/packages/openapi-core/src/shared/typescript-adapter.ts
+++ b/packages/openapi-core/src/shared/typescript-adapter.ts
@@ -10,6 +10,36 @@ export type TypeScriptValueReferenceResult = {
   diagnostic?: Diagnostic;
 };
 
+/**
+ * The pieces of a compiler type needed to recognise `Date`. Satisfied structurally
+ * by both the classic `ts.Type` and the native adapter's `NativeType`.
+ */
+type DateTypeLike = {
+  getSymbol?: (() => { name?: string | undefined } | undefined) | undefined;
+};
+
+/**
+ * `Date` is declared as an interface in `lib.es5.d.ts`, so a checker-driven
+ * conversion that expands object properties turns it into an object listing every
+ * `Date` prototype method rather than a date-time string. Both compiler adapters
+ * short-circuit it, and must do so before consulting their recursion guard —
+ * otherwise a second `Date` property collapses to a bare `{ type: "object" }`.
+ */
+export function isDateType<TType extends DateTypeLike>(
+  type: TType,
+  checker: { typeToString: (type: TType) => string },
+): boolean {
+  if (type.getSymbol?.()?.name === "Date") {
+    return true;
+  }
+
+  try {
+    return checker.typeToString(type) === "Date";
+  } catch {
+    return false;
+  }
+}
+
 export type TypeScriptCompilerAdapter = {
   kind: "classic" | "native";
   packagePath: string;

--- a/tests/fixtures/checker-date/types.ts
+++ b/tests/fixtures/checker-date/types.ts
@@ -1,0 +1,24 @@
+// Fixtures for `Date` properties resolved through a TypeScript checker rather than
+// the Babel AST path. Intersections are one of the constructs that route to the
+// checker (see `shouldUseTypeScriptChecker`), so they reproduce the real-world shape.
+
+export type AuditFields = {
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+// Intersection -> resolved by the checker, not the Babel AST walker.
+export type AuditedRecord = AuditFields & {
+  id: string;
+};
+
+// A single `Date` reached through the checker, without a sibling to exercise the
+// recursion guard.
+export type PublishedAt = AuditFields & {
+  publishedAt: Date;
+};
+
+// Plain alias -> handled by the Babel AST path; asserts both paths agree.
+export type PlainAudit = {
+  createdAt: Date;
+};

--- a/tests/integration/regressions/checker-date-expansion.test.ts
+++ b/tests/integration/regressions/checker-date-expansion.test.ts
@@ -1,0 +1,54 @@
+import path from "path";
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { SchemaProcessor } from "@workspace/openapi-core/schema/typescript/schema-processor.js";
+
+const DATE_TIME_SCHEMA = { type: "string", format: "date-time" };
+
+describe("Date properties resolved through a TypeScript checker", () => {
+  let processor: SchemaProcessor;
+
+  beforeEach(() => {
+    processor = new SchemaProcessor(
+      path.join(process.cwd(), "tests", "fixtures", "checker-date"),
+      "typescript",
+    );
+  });
+
+  it("emits a date-time string instead of expanding the Date prototype", () => {
+    const schema = processor.findSchemaDefinition("AuditedRecord", "");
+
+    expect(schema.properties?.createdAt).toEqual(DATE_TIME_SCHEMA);
+  });
+
+  it("emits date-time for every Date property, not just the first", () => {
+    const schema = processor.findSchemaDefinition("AuditedRecord", "");
+
+    // The recursion guard records resolved types by name, so a naive fix that runs
+    // after it leaves the second `Date` as a bare `{ type: "object" }`.
+    expect(schema.properties?.updatedAt).toEqual(DATE_TIME_SCHEMA);
+  });
+
+  it("does not leak Date prototype methods into properties", () => {
+    const schema = processor.findSchemaDefinition("AuditedRecord", "");
+    const createdAt = schema.properties?.createdAt as Record<string, unknown> | undefined;
+
+    expect(createdAt?.properties).toBeUndefined();
+    expect(createdAt?.required).toBeUndefined();
+    expect(JSON.stringify(schema)).not.toContain("toISOString");
+  });
+
+  it("resolves sibling Date properties declared across the intersection", () => {
+    const schema = processor.findSchemaDefinition("PublishedAt", "");
+
+    expect(schema.properties?.publishedAt).toEqual(DATE_TIME_SCHEMA);
+    expect(schema.properties?.createdAt).toEqual(DATE_TIME_SCHEMA);
+  });
+
+  it("agrees with the Babel AST path for a plain alias", () => {
+    const schema = processor.findSchemaDefinition("PlainAudit", "");
+
+    expect(schema.properties?.createdAt).toEqual(DATE_TIME_SCHEMA);
+  });
+});

--- a/tests/unit/schema/typescript/helpers.test.ts
+++ b/tests/unit/schema/typescript/helpers.test.ts
@@ -172,6 +172,23 @@ describe("TypeScript schema helpers", () => {
     expect(getExampleForParam("date")).toBe("2023-01-01");
     expect(getExampleForParam("role")).toBe("admin");
     expect(getExampleForParam("custom", "other")).toBe("example");
+
+    // A synthesized example must be a member of the schema's own enum.
+    expect(getExampleForParam("status", { type: "string", enum: ["active", "archived"] })).toBe(
+      "active",
+    );
+    // Enumerated values win over the name-based heuristics above.
+    expect(getExampleForParam("id", { type: "string", enum: ["first", "second"] })).toBe("first");
+    expect(getExampleForParam("page", { type: "number", enum: [10, 20] })).toBe(10);
+    expect(
+      getExampleForParam("organizationId", {
+        type: "string",
+        format: "uuid",
+        enum: ["11111111-1111-1111-1111-111111111111"],
+      }),
+    ).toBe("11111111-1111-1111-1111-111111111111");
+    // An empty enum carries no usable value, so the heuristics still apply.
+    expect(getExampleForParam("custom", { type: "string", enum: [] })).toBe("example");
     expect(detectContentType("UserBody", "text/plain")).toBe("text/plain");
     expect(detectContentType("MultipartFormData")).toBe("multipart/form-data");
     expect(detectContentType("UserBody")).toBe("application/json");

--- a/tests/unit/schema/typescript/schema-content.test.ts
+++ b/tests/unit/schema/typescript/schema-content.test.ts
@@ -159,6 +159,44 @@ describe("TypeScript schema content helpers", () => {
         example: "example",
       },
     ]);
+    // Enum-constrained parameters must not document an example their own schema
+    // rejects, so the synthesized value is the first allowed member.
+    expect(
+      createRequestParamsSchema({
+        properties: {
+          status: {
+            type: "string",
+            enum: ["in_progress", "completed", "failed"],
+            description: "Filter by status",
+          },
+        },
+      }),
+    ).toEqual([
+      {
+        in: "query",
+        name: "status",
+        schema: {
+          type: "string",
+          enum: ["in_progress", "completed", "failed"],
+          description: "Filter by status",
+        },
+        required: false,
+        description: "Filter by status",
+        example: "in_progress",
+      },
+    ]);
+    // An explicit example still wins over the synthesized one.
+    expect(
+      createRequestParamsSchema({
+        properties: {
+          status: {
+            type: "string",
+            enum: ["in_progress", "completed"],
+            example: "completed",
+          },
+        },
+      })[0],
+    ).toMatchObject({ example: "completed" });
     expect(createRequestBodySchema({ type: "string" })).toEqual({
       content: {
         "application/json": {

--- a/tests/unit/schema/typescript/schema-processor.test.ts
+++ b/tests/unit/schema/typescript/schema-processor.test.ts
@@ -96,7 +96,8 @@ describe("SchemaProcessor", () => {
         },
         required: true,
         description: "Filter status",
-        example: "example",
+        // First enum member: an example outside the enum is invalid against the schema.
+        example: "draft",
       },
     ]);
 


### PR DESCRIPTION
# Pull Request

## Description

Two independent correctness bugs that make generated documents wrong. Both are reproduced by new tests that fail without the fixes.

**1. `Date` expands into its prototype when resolved by a TypeScript checker**

`Date` is declared as an interface in `lib.es5.d.ts`, so the checker-driven conversions expand it via `getPropertiesOfType` into an object listing every `Date` prototype method rather than emitting `{ type: "string", format: "date-time" }`:

```json
"createdAt": {
  "type": "object",
  "properties": {
    "toString": { "type": "object" },
    "getTime": { "type": "object" },
    "toISOString": { "type": "object" },
    "__@toPrimitive@136": { "type": "object" }
  },
  "required": ["toString", "getTime", "toISOString", "__@toPrimitive@136", "..."]
}
```

A second `Date` property on the same type degrades further. The recursion guard records resolved types by name, so the sibling collapses to a bare `{ type: "object" }` — which is why the fix has to run *before* `seen` is consulted, not just before property expansion.

Both checker paths were affected. `typeScriptTypeToOpenApiSchema` (classic) has always had the gap, but it was unreachable in practice because the Babel AST path — which does handle `Date` — took over whenever the checker threw. Under TypeScript 7 the native adapter makes the checker path succeed, so `typeToOpenApiSchema` now hits it for real. Fixing only the native side would leave the classic path latent, so `isDateType` is shared by both.

Only constructs listed in `shouldUseTypeScriptChecker` reach these functions, so the fixture uses an intersection (`AuditFields & { id: string }`) to reproduce the real-world shape, and includes a plain-alias control that exercises the Babel path to confirm both agree.

**2. Synthesized parameter examples can violate their own schema**

Example synthesis is name- and type-driven, so an enum-constrained parameter falls through to the placeholder `"example"` — a value the parameter's own schema rejects:

```json
{
  "in": "query",
  "name": "status",
  "schema": { "type": "string", "enum": ["in_progress", "completed", "failed"] },
  "example": "example"
}
```

The document then fails validation, and UIs render an invalid value to API consumers. Parameters are the visible case because synthesis now runs for every parameter rather than path parameters only, so any enum-typed query parameter without an explicit example is affected.

When a schema enumerates its allowed values, every name-based guess is invalid by construction, so the first member is the only safe choice. The check runs ahead of the `format`/name heuristics so the stricter schema constraint wins, and an explicit `example` still takes precedence.

Note: an existing expectation in `schema-processor.test.ts` asserted `example: "example"` for a parameter declared `enum: ["draft", "published"]`, codifying the invalid output. It now expects the first enum member — that change is intentional, not incidental.

For context, this surfaced downstream on 1.7.0 in a project on TypeScript 7; it is currently carrying a `pnpm patch` with these two changes so it can stay on the current release.

## Type of Change

- [ ] ✨ **feat:** New feature
- [x] 🐛 **fix:** Bug fix
- [ ] 📝 **docs:** Documentation update
- [ ] ♻️ **refactor:** Code refactoring
- [ ] ⚡ **perf:** Performance improvement
- [ ] 💥 **Breaking change** (add `!` after type, e.g., `feat!:`)

## Checklist

- [x] `pnpm check` passes
- [x] Tested locally (`pnpm test` and `pnpm build` when relevant)
- [x] Documentation updated (if needed)

### Verification detail

- `pnpm test:unit` — 819 passed; `pnpm test:integration` — 139 passed (958 total across 129 files)
- `pnpm lint:root` and `pnpm exec turbo run check` — clean (24/24 tasks)
- `pnpm exec turbo run knip:ci` — clean
- `pnpm typecheck` — clean (10/10 tasks)
- Each new test was confirmed to fail without its fix: 4 of the 5 `Date` assertions fail with the prototype expansion (the plain-alias control keeps passing), and the enum assertions fail with `'example'` instead of the enum member.

Two things I deliberately left alone:

- `pnpm format` reformats `CHANGELOG.md` on a clean `main` (the release tooling emits `*` list markers where oxfmt wants `-`), so `pnpm check` is already red before my changes. It looked like it would just be re-broken by the next release, so I left it out rather than adding unrelated churn.
- Regenerating `apps/*/public/openapi.json` picks up the new `example` values, but also ~34k lines of unrelated drift versus the committed specs. I reverted those files to keep this reviewable — happy to include the regeneration if you'd prefer it here.

Adjacent gap I did not touch, since it is a separate behavior change: `Map` and `Set` have no case in either checker conversion either, so they prototype-expand the same way `Date` did.
