### PR TITLE
chore: drop redundant packageManager pins on internal packages

### DIFF
--- a/packages/openapi-cli/package.json
+++ b/packages/openapi-cli/package.json
@@ -46,6 +46,5 @@
   },
   "engines": {
     "node": ">=24.0.0"
-  },
-  "packageManager": "pnpm@11.9.0"
+  }
 }

--- a/packages/openapi-core/package.json
+++ b/packages/openapi-core/package.json
@@ -53,6 +53,5 @@
   },
   "engines": {
     "node": ">=24.0.0"
-  },
-  "packageManager": "pnpm@11.9.0"
+  }
 }

--- a/packages/openapi-framework-next/package.json
+++ b/packages/openapi-framework-next/package.json
@@ -42,6 +42,5 @@
   },
   "engines": {
     "node": ">=24.0.0"
-  },
-  "packageManager": "pnpm@11.9.0"
+  }
 }

--- a/packages/openapi-framework-react-router/package.json
+++ b/packages/openapi-framework-react-router/package.json
@@ -38,6 +38,5 @@
   },
   "engines": {
     "node": ">=24.0.0"
-  },
-  "packageManager": "pnpm@11.9.0"
+  }
 }

--- a/packages/openapi-framework-tanstack/package.json
+++ b/packages/openapi-framework-tanstack/package.json
@@ -38,6 +38,5 @@
   },
   "engines": {
     "node": ">=24.0.0"
-  },
-  "packageManager": "pnpm@11.9.0"
+  }
 }

--- a/packages/openapi-init/package.json
+++ b/packages/openapi-init/package.json
@@ -40,6 +40,5 @@
   },
   "engines": {
     "node": ">=24.0.0"
-  },
-  "packageManager": "pnpm@11.9.0"
+  }
 }


### PR DESCRIPTION
## Description

Skills audit leftover: nested `packageManager` fields on internal `@workspace/*` packages duplicate the root Corepack pin (`pnpm@11.9.0`). Remove them from `openapi-core`, `openapi-cli`, `openapi-init`, and the three framework packages. Keep the field on the public `next-openapi-gen` package and the repo root.

This is independent of the Next 16.3 and drizzle/docs PRs from the same audit.

## Type of Change

- [ ] ✨ **feat:** New feature
- [ ] 🐛 **fix:** Bug fix
- [ ] 📝 **docs:** Documentation update
- [ ] ♻️ **refactor:** Code refactoring
- [x] 🧹 **chore:** Workspace package metadata

## Checklist

- [x] `pnpm check` passes (format via pre-commit)
- [ ] Tested locally (`pnpm test` and `pnpm build` when relevant)
- [x] Documentation updated (if needed)

## Test plan

- [ ] Confirm root `package.json` still has `"packageManager": "pnpm@11.9.0"`
- [ ] Confirm `packages/next-openapi-gen/package.json` still has the Corepack pin
- [ ] `pnpm install` from a clean checkout still uses pnpm 11.9.0


Made with [Cursor](https://cursor.com)