### PR TITLE
refactor: compose sample home pages from compound parts

### DIFF
--- a/apps/next-app-adapter/src/app/home.tsx
+++ b/apps/next-app-adapter/src/app/home.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from "react";
+
+function Frame({ children }: { children: ReactNode }) {
+  return <main>{children}</main>;
+}
+
+function Lead({ children }: { children: ReactNode }) {
+  return <p>{children}</p>;
+}
+
+export const Home = {
+  Frame,
+  Lead,
+};

--- a/apps/next-app-adapter/src/app/page.tsx
+++ b/apps/next-app-adapter/src/app/page.tsx
@@ -1,3 +1,9 @@
+import { Home } from "./home";
+
 export default function HomePage() {
-  return <div>Open /api-docs to verify the Next adapter example.</div>;
+  return (
+    <Home.Frame>
+      <Home.Lead>Open /api-docs to verify the Next adapter example.</Home.Lead>
+    </Home.Frame>
+  );
 }

--- a/apps/next-app-drizzle-zod/src/app/home.tsx
+++ b/apps/next-app-drizzle-zod/src/app/home.tsx
@@ -1,0 +1,127 @@
+import type { ReactNode } from "react";
+
+function Frame({ children }: { children: ReactNode }) {
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-gray-50 to-gray-100 py-12 px-4">
+      <div className="max-w-4xl mx-auto">{children}</div>
+    </div>
+  );
+}
+
+function Header({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <header className="text-center mb-12">
+      <h1 className="text-4xl font-bold text-gray-900 mb-4">{title}</h1>
+      <p className="text-xl text-gray-600">{children}</p>
+    </header>
+  );
+}
+
+function Section({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section className="bg-white rounded-lg shadow-lg p-8 mb-8 last:mb-0">
+      <h2 className="text-2xl font-semibold mb-4">{title}</h2>
+      {children}
+    </section>
+  );
+}
+
+function FeatureList({ children }: { children: ReactNode }) {
+  return <ul className="space-y-3 text-gray-700">{children}</ul>;
+}
+
+function Feature({ name, children }: { name: string; children: ReactNode }) {
+  return (
+    <li className="flex items-start">
+      <span className="text-green-500 mr-2">✓</span>
+      <span>
+        <strong>{name}</strong> - {children}
+      </span>
+    </li>
+  );
+}
+
+function Step({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <div>
+      <h3 className="font-semibold text-gray-800 mb-2">{title}</h3>
+      {children}
+    </div>
+  );
+}
+
+function CodeSample({ children }: { children: ReactNode }) {
+  return <code className="block bg-gray-100 p-4 rounded text-sm overflow-x-auto">{children}</code>;
+}
+
+function EndpointList({ children }: { children: ReactNode }) {
+  return <div className="space-y-3">{children}</div>;
+}
+
+function Endpoint({
+  accentClassName,
+  method,
+  path,
+  children,
+}: {
+  accentClassName: string;
+  method: string;
+  path: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className={`border-l-4 ${accentClassName} pl-4`}>
+      <div className="font-mono text-sm text-gray-600">
+        {method} {path}
+      </div>
+      <div className="text-gray-700">{children}</div>
+    </div>
+  );
+}
+
+function GetEndpoint({ path, children }: { path: string; children: ReactNode }) {
+  return (
+    <Endpoint accentClassName="border-blue-500" method="GET" path={path}>
+      {children}
+    </Endpoint>
+  );
+}
+
+function PostEndpoint({ path, children }: { path: string; children: ReactNode }) {
+  return (
+    <Endpoint accentClassName="border-green-500" method="POST" path={path}>
+      {children}
+    </Endpoint>
+  );
+}
+
+function PatchEndpoint({ path, children }: { path: string; children: ReactNode }) {
+  return (
+    <Endpoint accentClassName="border-yellow-500" method="PATCH" path={path}>
+      {children}
+    </Endpoint>
+  );
+}
+
+function DeleteEndpoint({ path, children }: { path: string; children: ReactNode }) {
+  return (
+    <Endpoint accentClassName="border-red-500" method="DELETE" path={path}>
+      {children}
+    </Endpoint>
+  );
+}
+
+export const Home = {
+  Frame,
+  Header,
+  Section,
+  FeatureList,
+  Feature,
+  Step,
+  CodeSample,
+  EndpointList,
+  GetEndpoint,
+  PostEndpoint,
+  PatchEndpoint,
+  DeleteEndpoint,
+};

--- a/apps/next-app-drizzle-zod/src/app/page.tsx
+++ b/apps/next-app-drizzle-zod/src/app/page.tsx
@@ -1,70 +1,45 @@
 import Link from "next/link";
 
-export default function Home() {
+import { Home } from "./home";
+
+export default function HomePage() {
   return (
-    <div className="min-h-screen bg-gradient-to-b from-gray-50 to-gray-100 py-12 px-4">
-      <div className="max-w-4xl mx-auto">
-        <header className="text-center mb-12">
-          <h1 className="text-4xl font-bold text-gray-900 mb-4">Drizzle-Zod Blog API</h1>
-          <p className="text-xl text-gray-600">
-            Example Next.js API with Drizzle ORM, Zod validation, and OpenAPI documentation
-          </p>
-        </header>
+    <Home.Frame>
+      <Home.Header title="Drizzle-Zod Blog API">
+        Example Next.js API with Drizzle ORM, Zod validation, and OpenAPI documentation
+      </Home.Header>
 
-        <div className="bg-white rounded-lg shadow-lg p-8 mb-8">
-          <h2 className="text-2xl font-semibold mb-4">Features</h2>
-          <ul className="space-y-3 text-gray-700">
-            <li className="flex items-start">
-              <span className="text-green-500 mr-2">✓</span>
-              <span>
-                <strong>Drizzle ORM</strong> - Table schemas that drizzle-zod turns into Zod types
-              </span>
-            </li>
-            <li className="flex items-start">
-              <span className="text-green-500 mr-2">✓</span>
-              <span>
-                <strong>drizzle-zod</strong> - Auto-generated Zod schemas from Drizzle tables
-              </span>
-            </li>
-            <li className="flex items-start">
-              <span className="text-green-500 mr-2">✓</span>
-              <span>
-                <strong>next-openapi-gen</strong> - Automatic OpenAPI 3.0 documentation
-              </span>
-            </li>
-            <li className="flex items-start">
-              <span className="text-green-500 mr-2">✓</span>
-              <span>
-                <strong>Scalar UI</strong> - Modern API documentation interface
-              </span>
-            </li>
-          </ul>
-        </div>
+      <Home.Section title="Features">
+        <Home.FeatureList>
+          <Home.Feature name="Drizzle ORM">
+            Table schemas that drizzle-zod turns into Zod types
+          </Home.Feature>
+          <Home.Feature name="drizzle-zod">
+            Auto-generated Zod schemas from Drizzle tables
+          </Home.Feature>
+          <Home.Feature name="next-openapi-gen">Automatic OpenAPI 3.0 documentation</Home.Feature>
+          <Home.Feature name="Scalar UI">Modern API documentation interface</Home.Feature>
+        </Home.FeatureList>
+      </Home.Section>
 
-        <div className="bg-white rounded-lg shadow-lg p-8 mb-8">
-          <h2 className="text-2xl font-semibold mb-4">Quick Start</h2>
-          <div className="space-y-4">
-            <div>
-              <h3 className="font-semibold text-gray-800 mb-2">1. View API Documentation</h3>
-              <Link
-                href="/api-docs"
-                className="inline-block bg-blue-500 hover:bg-blue-600 text-white px-6 py-3 rounded-lg transition-colors"
-              >
-                Open API Docs →
-              </Link>
-            </div>
+      <Home.Section title="Quick Start">
+        <div className="space-y-4">
+          <Home.Step title="1. View API Documentation">
+            <Link
+              href="/api-docs"
+              className="inline-block bg-blue-500 hover:bg-blue-600 text-white px-6 py-3 rounded-lg transition-colors"
+            >
+              Open API Docs →
+            </Link>
+          </Home.Step>
 
-            <div>
-              <h3 className="font-semibold text-gray-800 mb-2">2. Try the API</h3>
-              <code className="block bg-gray-100 p-4 rounded text-sm overflow-x-auto">
-                curl http://localhost:3000/api/posts
-              </code>
-            </div>
+          <Home.Step title="2. Try the API">
+            <Home.CodeSample>curl http://localhost:3000/api/posts</Home.CodeSample>
+          </Home.Step>
 
-            <div>
-              <h3 className="font-semibold text-gray-800 mb-2">3. Create a Post</h3>
-              <code className="block bg-gray-100 p-4 rounded text-sm overflow-x-auto">
-                {`curl -X POST http://localhost:3000/api/posts \\
+          <Home.Step title="3. Create a Post">
+            <Home.CodeSample>
+              {`curl -X POST http://localhost:3000/api/posts \\
   -H "Content-Type: application/json" \\
   -d '{
     "title": "My First Post",
@@ -72,37 +47,20 @@ export default function Home() {
     "content": "Hello World!",
     "authorId": 1
   }'`}
-              </code>
-            </div>
-          </div>
+            </Home.CodeSample>
+          </Home.Step>
         </div>
+      </Home.Section>
 
-        <div className="bg-white rounded-lg shadow-lg p-8">
-          <h2 className="text-2xl font-semibold mb-4">Endpoints</h2>
-          <div className="space-y-3">
-            <div className="border-l-4 border-blue-500 pl-4">
-              <div className="font-mono text-sm text-gray-600">GET /api/posts</div>
-              <div className="text-gray-700">List all posts</div>
-            </div>
-            <div className="border-l-4 border-green-500 pl-4">
-              <div className="font-mono text-sm text-gray-600">POST /api/posts</div>
-              <div className="text-gray-700">Create a new post</div>
-            </div>
-            <div className="border-l-4 border-blue-500 pl-4">
-              <div className="font-mono text-sm text-gray-600">GET /api/posts/[id]</div>
-              <div className="text-gray-700">Get post by ID</div>
-            </div>
-            <div className="border-l-4 border-yellow-500 pl-4">
-              <div className="font-mono text-sm text-gray-600">PATCH /api/posts/[id]</div>
-              <div className="text-gray-700">Update post</div>
-            </div>
-            <div className="border-l-4 border-red-500 pl-4">
-              <div className="font-mono text-sm text-gray-600">DELETE /api/posts/[id]</div>
-              <div className="text-gray-700">Delete post</div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
+      <Home.Section title="Endpoints">
+        <Home.EndpointList>
+          <Home.GetEndpoint path="/api/posts">List all posts</Home.GetEndpoint>
+          <Home.PostEndpoint path="/api/posts">Create a new post</Home.PostEndpoint>
+          <Home.GetEndpoint path="/api/posts/[id]">Get post by ID</Home.GetEndpoint>
+          <Home.PatchEndpoint path="/api/posts/[id]">Update post</Home.PatchEndpoint>
+          <Home.DeleteEndpoint path="/api/posts/[id]">Delete post</Home.DeleteEndpoint>
+        </Home.EndpointList>
+      </Home.Section>
+    </Home.Frame>
   );
 }

--- a/apps/next-app-mixed-schemas/src/app/home.tsx
+++ b/apps/next-app-mixed-schemas/src/app/home.tsx
@@ -1,0 +1,74 @@
+import Link from "next/link";
+import type { CSSProperties, ReactNode } from "react";
+
+const pageStyle: CSSProperties = { padding: "2rem", fontFamily: "system-ui, sans-serif" };
+
+const docsLinkStyle: CSSProperties = {
+  display: "inline-block",
+  padding: "0.75rem 1.5rem",
+  backgroundColor: "#0070f3",
+  color: "white",
+  textDecoration: "none",
+  borderRadius: "5px",
+  fontWeight: "bold",
+};
+
+function Frame({ children }: { children: ReactNode }) {
+  return <main style={pageStyle}>{children}</main>;
+}
+
+function Header({ children }: { children: ReactNode }) {
+  return <h1>{children}</h1>;
+}
+
+function Intro({ children }: { children: ReactNode }) {
+  return <p>{children}</p>;
+}
+
+function Heading({ children }: { children: ReactNode }) {
+  return <h2>{children}</h2>;
+}
+
+function List({ children }: { children: ReactNode }) {
+  return <ul>{children}</ul>;
+}
+
+function Item({ name, children }: { name: string; children: ReactNode }) {
+  return (
+    <li>
+      <strong>{name}</strong> - {children}
+    </li>
+  );
+}
+
+function EndpointItem({ path, children }: { path: string; children: ReactNode }) {
+  return (
+    <li>
+      <code>{path}</code> - {children}
+    </li>
+  );
+}
+
+function Actions({ children }: { children: ReactNode }) {
+  return <div style={{ marginTop: "2rem" }}>{children}</div>;
+}
+
+function DocsLink({ children }: { children: ReactNode }) {
+  return (
+    <Link href="/api-docs" style={docsLinkStyle}>
+      {children}
+    </Link>
+  );
+}
+
+export const Home = {
+  Frame,
+  Header,
+  Intro,
+  Heading,
+  List,
+  Item,
+  EndpointItem,
+  Actions,
+  DocsLink,
+};

--- a/apps/next-app-mixed-schemas/src/app/page.tsx
+++ b/apps/next-app-mixed-schemas/src/app/page.tsx
@@ -1,63 +1,39 @@
-import Link from "next/link";
+import { Home } from "./home";
 
-export default function Home() {
+export default function HomePage() {
   return (
-    <div style={{ padding: "2rem", fontFamily: "system-ui, sans-serif" }}>
-      <h1>Mixed Schema Types API Example</h1>
-      <p>
+    <Home.Frame>
+      <Home.Header>Mixed Schema Types API Example</Home.Header>
+      <Home.Intro>
         This example demonstrates using <strong>multiple schema types</strong> simultaneously:
-      </p>
-      <ul>
-        <li>
-          <strong>Zod schemas</strong> - UserSchema, ProductSchema (
-          <code>src/schemas/zod-schemas.ts</code>)
-        </li>
-        <li>
-          <strong>TypeScript types</strong> - Order, OrderItem, PaginationParams (
-          <code>src/schemas/typescript-types.ts</code>)
-        </li>
-        <li>
-          <strong>Custom YAML schemas</strong> - Role, Permission, ApiMetadata (
-          <code>src/schemas/custom-schemas.yaml</code>)
-        </li>
-      </ul>
-      <h2>API Endpoints:</h2>
-      <ul>
-        <li>
-          <code>GET /api/users</code> - Uses Zod (UserSchema) + TypeScript (PaginationParams)
-        </li>
-        <li>
-          <code>POST /api/users</code> - Uses Zod (CreateUserSchema) + YAML (Role reference)
-        </li>
-        <li>
-          <code>GET /api/products</code> - Uses Zod schemas
-        </li>
-        <li>
-          <code>GET /api/orders</code> - Uses TypeScript types
-        </li>
-        <li>
-          <code>GET /api/roles</code> - Uses custom YAML schema
-        </li>
-        <li>
-          <code>GET /api/metadata</code> - Uses custom YAML schema
-        </li>
-      </ul>
-      <div style={{ marginTop: "2rem" }}>
-        <Link
-          href="/api-docs"
-          style={{
-            display: "inline-block",
-            padding: "0.75rem 1.5rem",
-            backgroundColor: "#0070f3",
-            color: "white",
-            textDecoration: "none",
-            borderRadius: "5px",
-            fontWeight: "bold",
-          }}
-        >
-          View API Documentation →
-        </Link>
-      </div>
-    </div>
+      </Home.Intro>
+      <Home.List>
+        <Home.Item name="Zod schemas">
+          UserSchema, ProductSchema (<code>src/schemas/zod-schemas.ts</code>)
+        </Home.Item>
+        <Home.Item name="TypeScript types">
+          Order, OrderItem, PaginationParams (<code>src/schemas/typescript-types.ts</code>)
+        </Home.Item>
+        <Home.Item name="Custom YAML schemas">
+          Role, Permission, ApiMetadata (<code>src/schemas/custom-schemas.yaml</code>)
+        </Home.Item>
+      </Home.List>
+      <Home.Heading>API Endpoints:</Home.Heading>
+      <Home.List>
+        <Home.EndpointItem path="GET /api/users">
+          Uses Zod (UserSchema) + TypeScript (PaginationParams)
+        </Home.EndpointItem>
+        <Home.EndpointItem path="POST /api/users">
+          Uses Zod (CreateUserSchema) + YAML (Role reference)
+        </Home.EndpointItem>
+        <Home.EndpointItem path="GET /api/products">Uses Zod schemas</Home.EndpointItem>
+        <Home.EndpointItem path="GET /api/orders">Uses TypeScript types</Home.EndpointItem>
+        <Home.EndpointItem path="GET /api/roles">Uses custom YAML schema</Home.EndpointItem>
+        <Home.EndpointItem path="GET /api/metadata">Uses custom YAML schema</Home.EndpointItem>
+      </Home.List>
+      <Home.Actions>
+        <Home.DocsLink>View API Documentation →</Home.DocsLink>
+      </Home.Actions>
+    </Home.Frame>
   );
 }

--- a/apps/next-app-next-config/src/app/home.tsx
+++ b/apps/next-app-next-config/src/app/home.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from "react";
+
+function Frame({ children }: { children: ReactNode }) {
+  return <main>{children}</main>;
+}
+
+function Lead({ children }: { children: ReactNode }) {
+  return <p>{children}</p>;
+}
+
+export const Home = {
+  Frame,
+  Lead,
+};

--- a/apps/next-app-next-config/src/app/page.tsx
+++ b/apps/next-app-next-config/src/app/page.tsx
@@ -1,3 +1,9 @@
+import { Home } from "./home";
+
 export default function HomePage() {
-  return <div>Open /api-docs to verify the next.config.ts integration example.</div>;
+  return (
+    <Home.Frame>
+      <Home.Lead>Open /api-docs to verify the next.config.ts integration example.</Home.Lead>
+    </Home.Frame>
+  );
 }

--- a/apps/next-app-sandbox/src/app/home.tsx
+++ b/apps/next-app-sandbox/src/app/home.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from "react";
+
+function Frame({ children }: { children: ReactNode }) {
+  return <main>{children}</main>;
+}
+
+function Lead({ children }: { children: ReactNode }) {
+  return <p>{children}</p>;
+}
+
+export const Home = {
+  Frame,
+  Lead,
+};

--- a/apps/next-app-sandbox/src/app/page.tsx
+++ b/apps/next-app-sandbox/src/app/page.tsx
@@ -1,3 +1,9 @@
-export default function Home() {
-  return <div>Go do /api-docs to check openapi example</div>;
+import { Home } from "./home";
+
+export default function HomePage() {
+  return (
+    <Home.Frame>
+      <Home.Lead>Go do /api-docs to check openapi example</Home.Lead>
+    </Home.Frame>
+  );
 }

--- a/apps/next-app-scalar/src/app/home.tsx
+++ b/apps/next-app-scalar/src/app/home.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from "react";
+
+function Frame({ children }: { children: ReactNode }) {
+  return <main>{children}</main>;
+}
+
+function Lead({ children }: { children: ReactNode }) {
+  return <p>{children}</p>;
+}
+
+export const Home = {
+  Frame,
+  Lead,
+};

--- a/apps/next-app-scalar/src/app/page.tsx
+++ b/apps/next-app-scalar/src/app/page.tsx
@@ -1,3 +1,9 @@
-export default function Home() {
-  return <div>Go do /api-docs to check Scalar example</div>;
+import { Home } from "./home";
+
+export default function HomePage() {
+  return (
+    <Home.Frame>
+      <Home.Lead>Go do /api-docs to check Scalar example</Home.Lead>
+    </Home.Frame>
+  );
 }

--- a/apps/next-app-swagger/src/app/home.tsx
+++ b/apps/next-app-swagger/src/app/home.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from "react";
+
+function Frame({ children }: { children: ReactNode }) {
+  return <main>{children}</main>;
+}
+
+function Lead({ children }: { children: ReactNode }) {
+  return <p>{children}</p>;
+}
+
+export const Home = {
+  Frame,
+  Lead,
+};

--- a/apps/next-app-swagger/src/app/page.tsx
+++ b/apps/next-app-swagger/src/app/page.tsx
@@ -1,3 +1,9 @@
-export default function Home() {
-  return <div>Go do /api-docs to check Swagger example</div>;
+import { Home } from "./home";
+
+export default function HomePage() {
+  return (
+    <Home.Frame>
+      <Home.Lead>Go do /api-docs to check Swagger example</Home.Lead>
+    </Home.Frame>
+  );
 }

--- a/apps/next-app-ts-config/src/app/home.tsx
+++ b/apps/next-app-ts-config/src/app/home.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from "react";
+
+function Frame({ children }: { children: ReactNode }) {
+  return <main>{children}</main>;
+}
+
+function Lead({ children }: { children: ReactNode }) {
+  return <p>{children}</p>;
+}
+
+export const Home = {
+  Frame,
+  Lead,
+};

--- a/apps/next-app-ts-config/src/app/page.tsx
+++ b/apps/next-app-ts-config/src/app/page.tsx
@@ -1,3 +1,9 @@
+import { Home } from "./home";
+
 export default function HomePage() {
-  return <div>Open /api-docs to verify typed openapi-gen.config.ts discovery.</div>;
+  return (
+    <Home.Frame>
+      <Home.Lead>Open /api-docs to verify typed openapi-gen.config.ts discovery.</Home.Lead>
+    </Home.Frame>
+  );
 }

--- a/apps/next-app-typescript/src/app/home.tsx
+++ b/apps/next-app-typescript/src/app/home.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from "react";
+
+function Frame({ children }: { children: ReactNode }) {
+  return <main>{children}</main>;
+}
+
+function Lead({ children }: { children: ReactNode }) {
+  return <p>{children}</p>;
+}
+
+export const Home = {
+  Frame,
+  Lead,
+};

--- a/apps/next-app-typescript/src/app/page.tsx
+++ b/apps/next-app-typescript/src/app/page.tsx
@@ -1,3 +1,9 @@
-export default function Home() {
-  return <div>Go do /api-docs to check TypeScript example</div>;
+import { Home } from "./home";
+
+export default function HomePage() {
+  return (
+    <Home.Frame>
+      <Home.Lead>Go do /api-docs to check TypeScript example</Home.Lead>
+    </Home.Frame>
+  );
 }

--- a/apps/next-app-zod/src/app/home.tsx
+++ b/apps/next-app-zod/src/app/home.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from "react";
+
+function Frame({ children }: { children: ReactNode }) {
+  return <main>{children}</main>;
+}
+
+function Lead({ children }: { children: ReactNode }) {
+  return <p>{children}</p>;
+}
+
+export const Home = {
+  Frame,
+  Lead,
+};

--- a/apps/next-app-zod/src/app/page.tsx
+++ b/apps/next-app-zod/src/app/page.tsx
@@ -1,3 +1,9 @@
-export default function Home() {
-  return <div>Go do /api-docs to check Zod example</div>;
+import { Home } from "./home";
+
+export default function HomePage() {
+  return (
+    <Home.Frame>
+      <Home.Lead>Go do /api-docs to check Zod example</Home.Lead>
+    </Home.Frame>
+  );
 }

--- a/apps/next-pages-router/components/home.tsx
+++ b/apps/next-pages-router/components/home.tsx
@@ -1,0 +1,51 @@
+import Link from "next/link";
+import type { CSSProperties, ReactNode } from "react";
+
+const pageStyle: CSSProperties = { padding: "2rem", fontFamily: "system-ui, sans-serif" };
+const docsLinkStyle: CSSProperties = { color: "#0070f3" };
+
+function Frame({ children }: { children: ReactNode }) {
+  return <main style={pageStyle}>{children}</main>;
+}
+
+function Header({ children }: { children: ReactNode }) {
+  return <h1>{children}</h1>;
+}
+
+function Intro({ children }: { children: ReactNode }) {
+  return <p>{children}</p>;
+}
+
+function Heading({ children }: { children: ReactNode }) {
+  return <h2>{children}</h2>;
+}
+
+function List({ children }: { children: ReactNode }) {
+  return <ul>{children}</ul>;
+}
+
+function EndpointItem({ path, children }: { path: string; children: ReactNode }) {
+  return (
+    <li>
+      <code>{path}</code> - {children}
+    </li>
+  );
+}
+
+function DocsLink({ children }: { children: ReactNode }) {
+  return (
+    <Link href="/api-docs" style={docsLinkStyle}>
+      {children}
+    </Link>
+  );
+}
+
+export const Home = {
+  Frame,
+  Header,
+  Intro,
+  Heading,
+  List,
+  EndpointItem,
+  DocsLink,
+};

--- a/apps/next-pages-router/pages/index.tsx
+++ b/apps/next-pages-router/pages/index.tsx
@@ -1,51 +1,29 @@
-import Link from "next/link";
+import { Home } from "../components/home";
 
-export default function Home() {
+export default function HomePage() {
   return (
-    <main style={{ padding: "2rem", fontFamily: "system-ui, sans-serif" }}>
-      <h1>Next.js Pages Router + next-openapi-gen</h1>
-      <p>
+    <Home.Frame>
+      <Home.Header>Next.js Pages Router + next-openapi-gen</Home.Header>
+      <Home.Intro>
         This is an example demonstrating how to use <code>next-openapi-gen</code> with the Pages
         Router.
-      </p>
-      <p>
-        <Link href="/api-docs" style={{ color: "#0070f3" }}>
-          View API Documentation
-        </Link>
-      </p>
-      <h2>Available Endpoints</h2>
-      <ul>
-        <li>
-          <code>GET /api/users</code> - List all users
-        </li>
-        <li>
-          <code>POST /api/users</code> - Create a new user
-        </li>
-        <li>
-          <code>GET /api/users/[id]</code> - Get user by ID
-        </li>
-        <li>
-          <code>PUT /api/users/[id]</code> - Update user
-        </li>
-        <li>
-          <code>DELETE /api/users/[id]</code> - Delete user
-        </li>
-        <li>
-          <code>GET /api/products</code> - List all products
-        </li>
-        <li>
-          <code>POST /api/products</code> - Create a new product
-        </li>
-        <li>
-          <code>GET /api/products/[id]</code> - Get product by ID
-        </li>
-        <li>
-          <code>PUT /api/products/[id]</code> - Update product
-        </li>
-        <li>
-          <code>DELETE /api/products/[id]</code> - Delete product
-        </li>
-      </ul>
-    </main>
+      </Home.Intro>
+      <Home.Intro>
+        <Home.DocsLink>View API Documentation</Home.DocsLink>
+      </Home.Intro>
+      <Home.Heading>Available Endpoints</Home.Heading>
+      <Home.List>
+        <Home.EndpointItem path="GET /api/users">List all users</Home.EndpointItem>
+        <Home.EndpointItem path="POST /api/users">Create a new user</Home.EndpointItem>
+        <Home.EndpointItem path="GET /api/users/[id]">Get user by ID</Home.EndpointItem>
+        <Home.EndpointItem path="PUT /api/users/[id]">Update user</Home.EndpointItem>
+        <Home.EndpointItem path="DELETE /api/users/[id]">Delete user</Home.EndpointItem>
+        <Home.EndpointItem path="GET /api/products">List all products</Home.EndpointItem>
+        <Home.EndpointItem path="POST /api/products">Create a new product</Home.EndpointItem>
+        <Home.EndpointItem path="GET /api/products/[id]">Get product by ID</Home.EndpointItem>
+        <Home.EndpointItem path="PUT /api/products/[id]">Update product</Home.EndpointItem>
+        <Home.EndpointItem path="DELETE /api/products/[id]">Delete product</Home.EndpointItem>
+      </Home.List>
+    </Home.Frame>
   );
 }

--- a/apps/react-router-app/src/home.tsx
+++ b/apps/react-router-app/src/home.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from "react";
+
+function Frame({ children }: { children: ReactNode }) {
+  return <main>{children}</main>;
+}
+
+function Header({ children }: { children: ReactNode }) {
+  return <h1>{children}</h1>;
+}
+
+function Lead({ children }: { children: ReactNode }) {
+  return <p>{children}</p>;
+}
+
+export const Home = {
+  Frame,
+  Header,
+  Lead,
+};

--- a/apps/react-router-app/src/routes/_index.tsx
+++ b/apps/react-router-app/src/routes/_index.tsx
@@ -1,8 +1,10 @@
+import { Home } from "../home";
+
 export default function HomePage() {
   return (
-    <main>
-      <h1>React Router API</h1>
-      <p>Open the generated API documentation at /api-docs.</p>
-    </main>
+    <Home.Frame>
+      <Home.Header>React Router API</Home.Header>
+      <Home.Lead>Open the generated API documentation at /api-docs.</Home.Lead>
+    </Home.Frame>
   );
 }

--- a/apps/tanstack-app/src/home.tsx
+++ b/apps/tanstack-app/src/home.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from "react";
+
+function Frame({ children }: { children: ReactNode }) {
+  return <main>{children}</main>;
+}
+
+function Header({ children }: { children: ReactNode }) {
+  return <h1>{children}</h1>;
+}
+
+function Lead({ children }: { children: ReactNode }) {
+  return <p>{children}</p>;
+}
+
+export const Home = {
+  Frame,
+  Header,
+  Lead,
+};

--- a/apps/tanstack-app/src/routes/index.tsx
+++ b/apps/tanstack-app/src/routes/index.tsx
@@ -1,14 +1,16 @@
 import { createFileRoute } from "@tanstack/react-router";
 
+import { Home } from "../home";
+
 export const Route = createFileRoute("/")({
   component: HomePage,
 });
 
 function HomePage() {
   return (
-    <main>
-      <h1>TanStack Router API</h1>
-      <p>Open the generated API documentation at /api-docs.</p>
-    </main>
+    <Home.Frame>
+      <Home.Header>TanStack Router API</Home.Header>
+      <Home.Lead>Open the generated API documentation at /api-docs.</Home.Lead>
+    </Home.Frame>
   );
 }


### PR DESCRIPTION
## Description

Refactor sample home pages to compound composition: each app colocate a `Home` object (`Frame`, copy, lists, actions) and the page composes those pieces. Visible copy and links are unchanged. Compound modules stay out of framework route folders (`pages/`, TanStack `routes/`) so they are not registered as extra routes.

## Type of Change

- [ ] ✨ **feat:** New feature
- [ ] 🐛 **fix:** Bug fix
- [ ] 📝 **docs:** Documentation update
- [x] ♻️ **refactor:** Code refactoring
- [ ] ⚡ **perf:** Performance improvement
- [ ] 💥 **Breaking change** (add `!` after type, e.g., `feat!:`)

## Checklist

- [x] `pnpm check` passes
- [x] Tested locally (`pnpm test` and `pnpm build` when relevant)
- [x] Documentation updated (if needed)

## Test plan

- [ ] Open a stub sample home (`next-app-zod`) and confirm the same lead copy
- [ ] Open `next-app-drizzle-zod` and `next-app-mixed-schemas` and confirm Features, endpoints, and the `/api-docs` link still work
- [ ] Confirm Pages Router, TanStack, and React Router homes still render and do not add a `/home` route


Made with [Cursor](https://cursor.com)