### PR TITLE
chore: tighten TypeScript, Oxlint, Oxfmt, and Knip configs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,7 @@
   "editor.formatOnSaveMode": "file",
   "editor.codeActionsOnSave": {
     "source.fixAll.oxc": "explicit",
-    "source.organizeImports": "explicit"
+    "source.organizeImports": "never"
   },
   "typescript.tsdk": "node_modules/@typescript/native/lib",
   "typescript.enablePromptUseWorkspaceTsdk": true,

--- a/apps/next-app-drizzle-zod/src/app/home.tsx
+++ b/apps/next-app-drizzle-zod/src/app/home.tsx
@@ -10,7 +10,6 @@ function Frame({ children }: { children: ReactNode }) {
 
 function Header({ title, children }: { title: string; children: ReactNode }) {
   return (
-<<<<<<< HEAD
     <header className="mb-12 text-center">
       <h1 data-testid="home-shell-marker" className="mb-4 text-4xl font-bold text-gray-900">
         {title}

--- a/apps/next-app-drizzle-zod/src/app/home.tsx
+++ b/apps/next-app-drizzle-zod/src/app/home.tsx
@@ -2,16 +2,17 @@ import type { ReactNode } from "react";
 
 function Frame({ children }: { children: ReactNode }) {
   return (
-    <div className="min-h-screen bg-gradient-to-b from-gray-50 to-gray-100 py-12 px-4">
-      <div className="max-w-4xl mx-auto">{children}</div>
+    <div className="min-h-screen bg-gradient-to-b from-gray-50 to-gray-100 px-4 py-12">
+      <div className="mx-auto max-w-4xl">{children}</div>
     </div>
   );
 }
 
 function Header({ title, children }: { title: string; children: ReactNode }) {
   return (
-    <header className="text-center mb-12">
-      <h1 data-testid="home-shell-marker" className="text-4xl font-bold text-gray-900 mb-4">
+<<<<<<< HEAD
+    <header className="mb-12 text-center">
+      <h1 data-testid="home-shell-marker" className="mb-4 text-4xl font-bold text-gray-900">
         {title}
       </h1>
       <p className="text-xl text-gray-600">{children}</p>
@@ -21,8 +22,8 @@ function Header({ title, children }: { title: string; children: ReactNode }) {
 
 function Section({ title, children }: { title: string; children: ReactNode }) {
   return (
-    <section className="bg-white rounded-lg shadow-lg p-8 mb-8 last:mb-0">
-      <h2 className="text-2xl font-semibold mb-4">{title}</h2>
+    <section className="mb-8 rounded-lg bg-white p-8 shadow-lg last:mb-0">
+      <h2 className="mb-4 text-2xl font-semibold">{title}</h2>
       {children}
     </section>
   );
@@ -35,7 +36,7 @@ function FeatureList({ children }: { children: ReactNode }) {
 function Feature({ name, children }: { name: string; children: ReactNode }) {
   return (
     <li className="flex items-start">
-      <span className="text-green-500 mr-2">✓</span>
+      <span className="mr-2 text-green-500">✓</span>
       <span>
         <strong>{name}</strong> - {children}
       </span>
@@ -46,14 +47,14 @@ function Feature({ name, children }: { name: string; children: ReactNode }) {
 function Step({ title, children }: { title: string; children: ReactNode }) {
   return (
     <div>
-      <h3 className="font-semibold text-gray-800 mb-2">{title}</h3>
+      <h3 className="mb-2 font-semibold text-gray-800">{title}</h3>
       {children}
     </div>
   );
 }
 
 function CodeSample({ children }: { children: ReactNode }) {
-  return <code className="block bg-gray-100 p-4 rounded text-sm overflow-x-auto">{children}</code>;
+  return <code className="block overflow-x-auto rounded bg-gray-100 p-4 text-sm">{children}</code>;
 }
 
 function EndpointList({ children }: { children: ReactNode }) {

--- a/apps/next-app-drizzle-zod/src/app/page.tsx
+++ b/apps/next-app-drizzle-zod/src/app/page.tsx
@@ -28,7 +28,7 @@ export default function HomePage() {
             <Link
               href="/api-docs"
               data-testid="api-docs-link"
-              className="inline-block bg-blue-500 hover:bg-blue-600 text-white px-6 py-3 rounded-lg transition-colors"
+              className="inline-block rounded-lg bg-blue-500 px-6 py-3 text-white transition-colors hover:bg-blue-600"
             >
               Open API Docs →
             </Link>

--- a/apps/next-app-typescript/src/app/api/products/route.utils.ts
+++ b/apps/next-app-typescript/src/app/api/products/route.utils.ts
@@ -69,7 +69,7 @@ export function createProduct(
  */
 export async function updateStock(
   id: string,
-  inStock: boolean,
+  _inStock: boolean,
 ): Promise<{ updated: boolean; productId: string; timestamp: string }> {
   // Simulate database update
   await new Promise((resolve) => setTimeout(resolve, 10));

--- a/apps/react-router-app/tsconfig.json
+++ b/apps/react-router-app/tsconfig.json
@@ -1,10 +1,6 @@
 {
-  "extends": "../../packages/typescript-config/base.json",
+  "extends": "../../packages/typescript-config/bundler.json",
   "compilerOptions": {
-    "jsx": "react-jsx",
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
-    "noEmit": true,
     "types": ["vite/client"]
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "vite.config.ts"],

--- a/apps/tanstack-app/tsconfig.json
+++ b/apps/tanstack-app/tsconfig.json
@@ -1,10 +1,6 @@
 {
-  "extends": "../../packages/typescript-config/base.json",
+  "extends": "../../packages/typescript-config/bundler.json",
   "compilerOptions": {
-    "jsx": "react-jsx",
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
-    "noEmit": true,
     "types": ["vite/client"]
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "vite.config.ts"],

--- a/knip.mts
+++ b/knip.mts
@@ -1,21 +1,21 @@
-import type { KnipConfig } from "knip";
+import type { KnipConfig, WorkspaceProjectConfig } from "knip";
 
-const nextApp = {
+const nextApp: WorkspaceProjectConfig = {
   project: ["**/*.{ts,tsx,js,jsx,mjs,mts,cjs,cts}"],
   next: true,
   typescript: true,
-} as const;
+};
 
-const nextAppWithPostcss = {
+const nextAppWithPostcss: WorkspaceProjectConfig = {
   ...nextApp,
   postcss: true,
-} as const;
+};
 
-const viteApp = {
+const viteApp: WorkspaceProjectConfig = {
   project: ["**/*.{ts,tsx,js,jsx,mjs,mts,cjs,cts}"],
   typescript: true,
   vite: true,
-} as const;
+};
 
 const config = {
   ignoreDependencies: [

--- a/knip.mts
+++ b/knip.mts
@@ -1,5 +1,22 @@
 import type { KnipConfig } from "knip";
 
+const nextApp = {
+  project: ["**/*.{ts,tsx,js,jsx,mjs,mts,cjs,cts}"],
+  next: true,
+  typescript: true,
+} as const;
+
+const nextAppWithPostcss = {
+  ...nextApp,
+  postcss: true,
+} as const;
+
+const viteApp = {
+  project: ["**/*.{ts,tsx,js,jsx,mjs,mts,cjs,cts}"],
+  typescript: true,
+  vite: true,
+} as const;
+
 const config = {
   ignoreDependencies: [
     "@commitlint/config-conventional",
@@ -18,23 +35,11 @@ const config = {
     "packages/next-openapi-gen/templates/**",
     "packages/openapi-init/templates/**",
     "tests/fixtures/**",
+    "apps/**/src/app/api/generated/**",
+    "apps/**/src/schemas/generated/**",
+    "apps/**/src/types/generated/**",
   ],
-  ignoreIssues: {
-    "apps/next-app-mixed-schemas/package.json": ["devDependencies"],
-    "apps/next-app-sandbox/package.json": ["devDependencies"],
-    "apps/next-app-scalar/package.json": ["devDependencies"],
-    "apps/next-app-swagger/package.json": ["devDependencies"],
-    "apps/next-app-typescript/package.json": ["devDependencies"],
-    "apps/next-app-zod/package.json": ["devDependencies"],
-    "apps/next-app-adapter/package.json": ["devDependencies"],
-    "apps/next-app-next-config/package.json": ["devDependencies"],
-    "apps/next-app-ts-config/package.json": ["devDependencies"],
-    "apps/next-pages-router/package.json": ["devDependencies"],
-    "apps/react-router-app/package.json": ["devDependencies"],
-    "apps/tanstack-app/package.json": ["devDependencies"],
-    "packages/next-openapi-gen/package.json": ["dependencies"],
-  },
-  ignoreUnresolved: ["next", "./routeTree.gen"],
+  ignoreUnresolved: ["./routeTree.gen"],
   workspaces: {
     ".": {
       entry: ["*.{json,ts,mts,cts}", ".github/workflows/*.{yml,yaml}"],
@@ -50,23 +55,93 @@ const config = {
       typescript: true,
       vitest: true,
     },
-    "apps/*": {
+    "apps/next-app-adapter": {
+      ...nextApp,
       entry: [
         "openapi-gen.config.ts",
         "next.openapi.json",
         "next-openapi.adapter.mjs",
-        "next-openapi.config.ts",
-        "schemas/**/*.{ts,tsx}",
+        "src/schemas/**/*.{ts,tsx}",
+      ],
+      ignoreDependencies: ["ajv", "autoprefixer", "postcss"],
+    },
+    "apps/next-app-drizzle-zod": {
+      ...nextAppWithPostcss,
+      entry: [
+        "openapi-gen.config.ts",
+        "next.openapi.json",
         "src/db/**/*.{ts,tsx}",
-        "src/router.tsx",
-        "src/routes/**/*.{ts,tsx}",
+        "src/schemas/**/*.{ts,tsx}",
+      ],
+    },
+    "apps/next-app-mixed-schemas": {
+      ...nextApp,
+      entry: [
+        "openapi-gen.config.ts",
+        "next.openapi.json",
         "src/schemas/**/*.{ts,tsx}",
         "src/types/**/*.{ts,tsx}",
       ],
-      project: ["**/*.{ts,tsx,js,jsx,mjs,mts,cjs,cts}"],
-      next: true,
-      postcss: true,
-      typescript: true,
+    },
+    "apps/next-app-next-config": {
+      ...nextApp,
+      entry: ["openapi-gen.config.ts", "next-openapi.config.ts", "src/schemas/**/*.{ts,tsx}"],
+      ignoreDependencies: ["ajv", "autoprefixer", "postcss"],
+    },
+    "apps/next-app-sandbox": {
+      ...nextAppWithPostcss,
+      entry: ["openapi-gen.config.ts", "next.openapi.json"],
+      ignoreDependencies: ["ajv"],
+    },
+    "apps/next-app-scalar": {
+      ...nextAppWithPostcss,
+      entry: ["openapi-gen.config.ts", "next.openapi.json"],
+      ignoreDependencies: ["ajv", "zod"],
+    },
+    "apps/next-app-swagger": {
+      ...nextApp,
+      entry: ["openapi-gen.config.ts", "next.openapi.json"],
+      ignoreDependencies: ["zod"],
+    },
+    "apps/next-app-ts-config": {
+      ...nextApp,
+      entry: ["openapi-gen.config.ts", "next-openapi.config.ts", "src/schemas/**/*.{ts,tsx}"],
+      ignoreDependencies: ["ajv", "autoprefixer", "postcss"],
+    },
+    "apps/next-app-typescript": {
+      ...nextAppWithPostcss,
+      entry: ["openapi-gen.config.ts", "next.openapi.json", "src/types/**/*.{ts,tsx}"],
+      ignoreDependencies: ["ajv"],
+    },
+    "apps/next-app-zod": {
+      ...nextAppWithPostcss,
+      entry: ["openapi-gen.config.ts", "next.openapi.json", "src/schemas/**/*.{ts,tsx}"],
+      ignoreDependencies: ["ajv"],
+    },
+    "apps/next-pages-router": {
+      ...nextApp,
+      entry: ["openapi-gen.config.ts", "next.openapi.json", "schemas/**/*.{ts,tsx}"],
+    },
+    "apps/react-router-app": {
+      ...viteApp,
+      entry: [
+        "openapi-gen.config.ts",
+        "next.openapi.json",
+        "src/routes/**/*.{ts,tsx}",
+        "src/schemas/**/*.{ts,tsx}",
+      ],
+      ignoreDependencies: ["ajv"],
+    },
+    "apps/tanstack-app": {
+      ...viteApp,
+      entry: [
+        "openapi-gen.config.ts",
+        "next.openapi.json",
+        "src/router.tsx",
+        "src/routes/**/*.{ts,tsx}",
+        "src/schemas/**/*.{ts,tsx}",
+      ],
+      ignoreDependencies: ["ajv"],
     },
     "packages/*": {
       project: ["**/*.{ts,tsx,js,jsx,mjs,mts,cjs,cts,json}"],
@@ -76,6 +151,18 @@ const config = {
     },
     "packages/next-openapi-gen": {
       entry: ["src/index.ts"],
+      ignoreDependencies: [
+        "@babel/parser",
+        "@babel/traverse",
+        "@babel/types",
+        "commander",
+        "fs-extra",
+        "js-yaml",
+        "ora",
+      ],
+    },
+    "packages/typescript-config": {
+      ignoreUnresolved: ["next"],
     },
     tests: {
       entry: ["bench/**/*.ts", "**/*.{test,spec}.ts", "**/*.{test,spec}.tsx"],

--- a/packages/oxfmt-config/index.ts
+++ b/packages/oxfmt-config/index.ts
@@ -1,7 +1,6 @@
 import { defineConfig, type OxfmtConfig } from "oxfmt";
 
 const oxfmtConfig = defineConfig({
-  printWidth: 100,
   sortImports: {
     ignoreCase: true,
     internalPattern: ["@workspace/", "@next-openapi-gen"],
@@ -11,6 +10,7 @@ const oxfmtConfig = defineConfig({
   sortPackageJson: {
     sortScripts: true,
   },
+  sortTailwindcss: {},
   overrides: [
     {
       files: ["**/*.md"],

--- a/packages/oxlint-config/base.ts
+++ b/packages/oxlint-config/base.ts
@@ -2,10 +2,11 @@ import { defineConfig, type OxlintConfig } from "oxlint";
 
 import coreConfig from "./core.ts";
 import nextConfig from "./next.ts";
+import reactConfig from "./react.ts";
 import vitestConfig from "./vitest.ts";
 
 const baseConfig = defineConfig({
-  extends: [coreConfig, nextConfig, vitestConfig],
+  extends: [coreConfig, reactConfig, nextConfig, vitestConfig],
 }) satisfies OxlintConfig;
 
 export default baseConfig;

--- a/packages/oxlint-config/core.ts
+++ b/packages/oxlint-config/core.ts
@@ -1,19 +1,8 @@
 import { defineConfig, type OxlintConfig } from "oxlint";
 
 const coreConfig = defineConfig({
-  plugins: [
-    "eslint",
-    "typescript",
-    "unicorn",
-    "oxc",
-    "import",
-    "node",
-    "promise",
-    "react",
-    "react-perf",
-  ],
+  plugins: ["eslint", "typescript", "unicorn", "oxc", "import", "node", "promise"],
   env: {
-    browser: true,
     node: true,
   },
   categories: {
@@ -43,15 +32,6 @@ const coreConfig = defineConfig({
     "no-shadow": "off",
     "import/no-unassigned-import": "off",
     "promise/prefer-await-to-then": "off",
-    "react/react-in-jsx-scope": "off",
-    "react/jsx-filename-extension": "off",
-    "react/jsx-props-no-spreading": "off",
-    "react/no-unknown-property": "off",
-    "react/only-export-components": "off",
-    "react-perf/jsx-no-jsx-as-prop": "off",
-    "react-perf/jsx-no-new-array-as-prop": "off",
-    "react-perf/jsx-no-new-function-as-prop": "off",
-    "react-perf/jsx-no-new-object-as-prop": "off",
     "unicorn/consistent-function-scoping": "off",
     "typescript/await-thenable": "error",
     "typescript/consistent-type-imports": "off",

--- a/packages/oxlint-config/index.ts
+++ b/packages/oxlint-config/index.ts
@@ -2,4 +2,5 @@ export { default as baseConfig, default } from "./base.ts";
 export { default as coreConfig } from "./core.ts";
 export { ignorePatterns } from "./ignores.ts";
 export { default as nextConfig } from "./next.ts";
+export { default as reactConfig } from "./react.ts";
 export { default as vitestConfig } from "./vitest.ts";

--- a/packages/oxlint-config/next.ts
+++ b/packages/oxlint-config/next.ts
@@ -1,7 +1,6 @@
 import { defineConfig, type OxlintConfig } from "oxlint";
 
 const nextConfig = defineConfig({
-  plugins: ["nextjs"],
   settings: {
     next: {
       rootDir: [
@@ -22,8 +21,15 @@ const nextConfig = defineConfig({
   overrides: [
     {
       files: [
-        "**/src/app/**/*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}",
-        "**/pages/**/*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}",
+        "apps/next-app-*/**/*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}",
+        "apps/next-pages-router/**/*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}",
+      ],
+      plugins: ["nextjs"],
+    },
+    {
+      files: [
+        "**/src/app/**/route.{js,jsx,ts,tsx,mjs,cjs,mts,cts}",
+        "**/pages/api/**/*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}",
         "**/src/schemas/**/*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}",
         "**/src/types/**/*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}",
       ],

--- a/packages/oxlint-config/package.json
+++ b/packages/oxlint-config/package.json
@@ -9,6 +9,7 @@
     "./core": "./core.ts",
     "./ignores": "./ignores.ts",
     "./next": "./next.ts",
+    "./react": "./react.ts",
     "./vitest": "./vitest.ts"
   },
   "scripts": {

--- a/packages/oxlint-config/react.ts
+++ b/packages/oxlint-config/react.ts
@@ -1,0 +1,20 @@
+import { defineConfig, type OxlintConfig } from "oxlint";
+
+const reactConfig = defineConfig({
+  overrides: [
+    {
+      files: ["apps/**/*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}"],
+      plugins: ["react", "jsx-a11y"],
+      env: {
+        browser: true,
+      },
+      rules: {
+        "react/jsx-filename-extension": "off",
+        "react/react-compiler": "error",
+        "react/react-in-jsx-scope": "off",
+      },
+    },
+  ],
+}) satisfies OxlintConfig;
+
+export default reactConfig;

--- a/packages/typescript-config/base.json
+++ b/packages/typescript-config/base.json
@@ -13,6 +13,8 @@
     "module": "NodeNext",
     "moduleDetection": "force",
     "moduleResolution": "NodeNext",
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
     "noUncheckedSideEffectImports": true,
     "noUncheckedIndexedAccess": true,
     "resolveJsonModule": true,

--- a/packages/typescript-config/bundler.json
+++ b/packages/typescript-config/bundler.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "Bundler",
+  "extends": "./base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "lib": ["ES2024", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noEmit": true
+  }
+}


### PR DESCRIPTION
## Description

Tighten TypeScript, Oxlint, Oxfmt, and Knip so they stay closer to tool defaults, with only the extra strictness this repo actually needs.

- TypeScript: enable `noImplicitOverride` and `noFallthroughCasesInSwitch`, keep Node libs in `base.json`, and add a Vite `bundler.json` preset.
- Oxlint: drop dead `react-perf` config, scope React/Next/jsx-a11y to apps, enable `react/react-compiler`, and keep unused-var exemptions on route/schema files only.
- Oxfmt: drop redundant `printWidth`, enable Tailwind class sorting, and stop VS Code organize-imports from fighting Oxfmt.
- Knip: use Next vs Vite plugins per app, replace blanket ignores with leftover-only exceptions, and treat config hints as errors.

## Type of Change

- [ ] ✨ **feat:** New feature
- [ ] 🐛 **fix:** Bug fix
- [ ] 📝 **docs:** Documentation update
- [ ] ♻️ **refactor:** Code refactoring
- [ ] ⚡ **perf:** Performance improvement
- [ ] 💥 **Breaking change** (add `!` after type, e.g., `feat!:`)

This is a `chore` tooling change (no conventional-commit type checkbox for that in the template).

## Checklist

- [x] `pnpm check` passes
- [x] Tested locally (`pnpm test` and `pnpm build` when relevant)
- [ ] Documentation updated (if needed)


Made with [Cursor](https://cursor.com)